### PR TITLE
fix(ladybug): make Entity/edge embedding search work on strict binder

### DIFF
--- a/pkg/driver/ladybug.go
+++ b/pkg/driver/ladybug.go
@@ -1537,7 +1537,7 @@ func (k *LadybugDriver) SearchEdgesByEmbedding(ctx context.Context, embedding []
 	// Uses RelatesToNode_ intermediate representation
 	query := `
 		MATCH (n:Entity)-[:RELATES_TO]->(e:RelatesToNode_)-[:RELATES_TO]->(m:Entity)
-		WHERE e.group_id = $group_id
+		WHERE e.group_id = $group_id AND size(e.fact_embedding) = ` + fmt.Sprintf("%d", len(embedding)) + `
 		WITH DISTINCT e, n, m, array_cosine_similarity(e.fact_embedding, CAST($search_vector AS FLOAT[` + fmt.Sprintf("%d", len(embedding)) + `])) AS score
 		WHERE score > 0.0
 		RETURN

--- a/pkg/search/graph_traversal.go
+++ b/pkg/search/graph_traversal.go
@@ -121,6 +121,17 @@ func (su *SearchUtilities) NodeBFSSearch(ctx context.Context, originNodeUUIDs []
 	// Execute queries and collect results
 	allRecords := []map[string]interface{}{}
 
+	// Entity nodes carry their embedding in name_embedding; only the Rule node
+	// table has a plain `embedding` column. Ladybug binds properties strictly to
+	// the matched node table's schema, so selecting n.embedding on (n:Entity)
+	// raises "Cannot find property embedding for n". Omit it for Ladybug; other
+	// backends are schema-lenient and return null harmlessly (convertRecordsToNodes
+	// already treats embedding as optional).
+	embeddingReturn := ",\n\t\t\t\tn.embedding AS embedding"
+	if provider == driver.GraphProviderLadybug {
+		embeddingReturn = ""
+	}
+
 	for _, matchQuery := range matchQueries {
 		query := matchQuery + filterQuery + `
 			RETURN
@@ -130,8 +141,7 @@ func (su *SearchUtilities) NodeBFSSearch(ctx context.Context, originNodeUUIDs []
 				n.name_embedding AS name_embedding,
 				n.labels AS labels,
 				n.created_at AS created_at,
-				n.summary AS summary,
-				n.embedding AS embedding
+				n.summary AS summary` + embeddingReturn + `
 			LIMIT $limit
 		`
 


### PR DESCRIPTION
Two query bugs surfaced running hybrid search against LadybugDB graphs, which (unlike Neo4j/DuckPGQ) binds properties strictly to the matched node table's schema.

- search/graph_traversal.go: the BFS node search matched (n:Entity) but RETURNed n.embedding, a column that only exists on the Rule table, not Entity (Entity carries its vector in name_embedding). Ladybug raised "Cannot find property embedding for n". Omit n.embedding from the RETURN for the Ladybug provider; other backends are schema-lenient and convertRecordsToNodes already treats embedding as optional.

- driver/ladybug.go: SearchEdgesByEmbedding called array_cosine_similarity on e.fact_embedding with no size guard, so an edge whose fact_embedding is empty crashed the whole query with "Unsupported casting LIST ... Expected: N, Actual: 0". Add the same size(e.fact_embedding) = N filter the node search already uses, so edges without embeddings are skipped instead of aborting the search.