### PR TITLE
server: OpenAI-compatible /api/v1/embeddings endpoint

### DIFF
--- a/pkg/server/handlers/embed.go
+++ b/pkg/server/handlers/embed.go
@@ -1,8 +1,11 @@
 package handlers
 
 import (
+	"encoding/base64"
+	"encoding/binary"
 	"encoding/json"
 	"fmt"
+	"math"
 	"net/http"
 
 	"github.com/soundprediction/predicato/pkg/embedder"
@@ -89,5 +92,97 @@ func (h *EmbedHandler) Embed(w http.ResponseWriter, r *http.Request) {
 		Embeddings: embeddings,
 		Model:      h.model,
 		Dimensions: h.embedder.Dimensions(),
+	})
+}
+
+// OpenAI-compatible embeddings (POST /api/v1/embeddings) so any OpenAI-embeddings
+// client can use predicato as a drop-in embedding provider. Because it runs the
+// SAME embedder this process is configured with, embeddings are byte-for-byte
+// identical to the in-process path — no re-embedding or consistency drift — which
+// is exactly what lets the embedder run as a separate, poolable service in front
+// of stores embedded by the same model.
+
+type openAIEmbedRequest struct {
+	Input json.RawMessage `json:"input"` // a single string or an array of strings
+	Model string          `json:"model"`
+	// EncodingFormat is "float" (array of numbers, OpenAI default) or "base64"
+	// (little-endian float32 bytes, base64-encoded). The official openai clients
+	// default to base64 on the wire, so we must honor it for drop-in compatibility.
+	EncodingFormat string `json:"encoding_format"`
+}
+
+type openAIEmbedData struct {
+	Object    string `json:"object"`
+	Embedding any    `json:"embedding"` // []float32 (float) or string (base64)
+	Index     int    `json:"index"`
+}
+
+// base64Float32 encodes a vector as the base64 of its little-endian float32 bytes,
+// matching what OpenAI-compatible clients decode when encoding_format=base64.
+func base64Float32(vec []float32) string {
+	buf := make([]byte, 4*len(vec))
+	for i, f := range vec {
+		binary.LittleEndian.PutUint32(buf[i*4:], math.Float32bits(f))
+	}
+	return base64.StdEncoding.EncodeToString(buf)
+}
+
+type openAIEmbedResponse struct {
+	Object string            `json:"object"`
+	Data   []openAIEmbedData `json:"data"`
+	Model  string            `json:"model"`
+	Usage  map[string]int    `json:"usage"`
+}
+
+// OpenAIEmbeddings handles POST /api/v1/embeddings (OpenAI shape).
+func (h *EmbedHandler) OpenAIEmbeddings(w http.ResponseWriter, r *http.Request) {
+	if h.embedder == nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]any{"error": map[string]string{"message": "embedding model not configured"}})
+		return
+	}
+	var req openAIEmbedRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]any{"error": map[string]string{"message": "invalid request body"}})
+		return
+	}
+	// input may be a single string or an array of strings.
+	var texts []string
+	if err := json.Unmarshal(req.Input, &texts); err != nil {
+		var one string
+		if err2 := json.Unmarshal(req.Input, &one); err2 != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]any{"error": map[string]string{"message": "input must be a string or array of strings"}})
+			return
+		}
+		texts = []string{one}
+	}
+	if len(texts) == 0 {
+		writeJSON(w, http.StatusBadRequest, map[string]any{"error": map[string]string{"message": "input is required"}})
+		return
+	}
+	embeddings, err := h.embedder.Embed(r.Context(), texts)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]any{"error": map[string]string{"message": fmt.Sprintf("embedding failed: %v", err)}})
+		return
+	}
+	base64Out := req.EncodingFormat == "base64"
+	data := make([]openAIEmbedData, len(embeddings))
+	for i, e := range embeddings {
+		d := openAIEmbedData{Object: "embedding", Index: i}
+		if base64Out {
+			d.Embedding = base64Float32(e)
+		} else {
+			d.Embedding = e
+		}
+		data[i] = d
+	}
+	model := req.Model
+	if model == "" {
+		model = h.model
+	}
+	writeJSON(w, http.StatusOK, openAIEmbedResponse{
+		Object: "list",
+		Data:   data,
+		Model:  model,
+		Usage:  map[string]int{"prompt_tokens": 0, "total_tokens": 0},
 	})
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -100,8 +100,12 @@ func (s *Server) setupRoutes() {
 			r.Post("/extract-source", nlpHandler.ExtractSource)
 		})
 
-		// Embedding route - generate embeddings using configured embedder
+		// Embedding routes - generate embeddings using the configured embedder.
+		// /embed is predicato's native shape; /embeddings is OpenAI-compatible so an
+		// OpenAI-embeddings client can use this server as a drop-in (and poolable)
+		// embedding provider running the same model.
 		r.Post("/embed", embedHandler.Embed)
+		r.Post("/embeddings", embedHandler.OpenAIEmbeddings)
 
 		// Extended extraction route - extract entities, relations, triples, rules
 		if s.nlpClient != nil {


### PR DESCRIPTION
Serve the same in-process embedder behind an OpenAI-shaped embeddings API so any OpenAI-embeddings client can use a predicato server as a drop-in, poolable embedding provider. Honors encoding_format (float or base64).

Note: backed by predicato's candle pipeline — for predicato-native deployments. (humn's embedder externalization uses go-embedeverything serve, a different library, for byte-consistency with its stored vectors.)