### PR TITLE
ruleschema: structured conditional rules (Phase 1 — representation + storage)

### DIFF
--- a/cmd/backfill-source/main.go
+++ b/cmd/backfill-source/main.go
@@ -1,0 +1,342 @@
+//go:build cgo && system_ladybug
+
+// backfill-source augments an existing ladybug knowledge graph IN PLACE with the
+// upstream source provenance that was dropped when the graph was first imported
+// from an aggregator (PrimeKG's DuckDB kept "name + type only, no xref IDs").
+//
+// It joins each Entity to PrimeKG's raw nodes.tab by name (names are ~99.9% unique;
+// the rare collision is disambiguated by type) and writes, into the entity's
+// `attributes` JSON, the resolvable upstream reference:
+//   - xrefs:       ["GO:0051581"]              (canonical CURIE)
+//   - source_urls: ["https://amigo.geneontology.org/amigo/term/GO:0051581"]
+//
+// Non-destructive and idempotent: only entities whose xrefs are still empty
+// (attributes contains `"xrefs": []`) are touched, so re-runs resume cleanly and
+// nothing already-sourced is overwritten. Reads in LIMIT chunks over that filter
+// (embedded rows drop out of the filter, so successive chunks advance), writing
+// back via point-lookup SET on the uuid hash index. Modeled on backfill-embeddings.
+package main
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/soundprediction/predicato/pkg/driver"
+)
+
+// pkgEntry is one PrimeKG node: its source DB, the id within that DB, and its type.
+type pkgEntry struct {
+	source string
+	id     string
+	ntype  string
+}
+
+func main() {
+	dbPath := flag.String("db", "", "path to .ladybug database to augment (required)")
+	nodesTab := flag.String("primekg-nodes", "", "path to PrimeKG raw nodes.tab (required)")
+	chunkSz := flag.Int("chunk", 50000, "entities pulled per DB scan")
+	ckptEvery := flag.Int("checkpoint-every", 2000, "checkpoint every N written rows")
+	bufBytes := flag.Uint64("buffer-pool-bytes", 8<<30, "ladybug buffer pool size in bytes")
+	dryRun := flag.Bool("dry-run", false, "report matches without writing")
+	maxChunks := flag.Int("max-chunks", 0, "stop after N chunks (0=unlimited; for sampling)")
+	flag.Parse()
+	if *dbPath == "" || *nodesTab == "" {
+		log.Fatal("--db and --primekg-nodes are required")
+	}
+	ctx := context.Background()
+
+	index := loadPrimeKG(*nodesTab)
+	log.Printf("loaded %d PrimeKG node names", len(index))
+
+	cfg := driver.DefaultLadybugDriverConfig()
+	cfg.DBPath = *dbPath
+	cfg.ReadOnly = *dryRun
+	cfg.BufferPoolSize = *bufBytes
+	d, err := driver.NewLadybugDriverWithConfig(cfg)
+	if err != nil {
+		log.Fatalf("open %s: %v", *dbPath, err)
+	}
+	defer d.Close()
+
+	backfill(ctx, d, index, *chunkSz, *ckptEvery, *maxChunks, *dryRun)
+}
+
+// loadPrimeKG reads nodes.tab (node_index, node_id, node_type, node_name, node_source)
+// into a name-keyed index. Values are slices so a colliding name keeps all sources
+// for type-based disambiguation at join time.
+func loadPrimeKG(path string) map[string][]pkgEntry {
+	f, err := os.Open(path)
+	if err != nil {
+		log.Fatalf("open %s: %v", path, err)
+	}
+	defer f.Close()
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 1<<20), 1<<20)
+	index := make(map[string][]pkgEntry, 130000)
+	first := true
+	for sc.Scan() {
+		if first { // header
+			first = false
+			continue
+		}
+		cols := strings.Split(sc.Text(), "\t")
+		if len(cols) < 5 {
+			continue
+		}
+		id := strings.Trim(cols[1], `"`)
+		ntype := strings.Trim(cols[2], `"`)
+		name := strings.Trim(cols[3], `"`)
+		source := strings.Trim(cols[4], `"`)
+		if name == "" || id == "" || source == "" {
+			continue
+		}
+		key := strings.ToLower(strings.TrimSpace(name))
+		index[key] = append(index[key], pkgEntry{source: source, id: id, ntype: ntype})
+	}
+	if err := sc.Err(); err != nil {
+		log.Fatalf("scan %s: %v", path, err)
+	}
+	return index
+}
+
+func backfill(ctx context.Context, d *driver.LadybugDriver, index map[string][]pkgEntry, chunkSz, ckptEvery, maxChunks int, dryRun bool) {
+	// Un-backfilled entities still carry the import's empty `"xrefs": []`.
+	miss := `r.attributes IS NOT NULL AND r.attributes CONTAINS '"xrefs": []'`
+	total := count(ctx, d, fmt.Sprintf("MATCH (r:Entity) WHERE %s RETURN count(r) AS c", miss))
+	log.Printf("%d entities without xrefs", total)
+	if total == 0 {
+		return
+	}
+	selChunk := fmt.Sprintf("MATCH (r:Entity) WHERE %s RETURN r.uuid AS uuid, r.name AS name, r.attributes AS attrs LIMIT %d", miss, chunkSz)
+	setQ := "MATCH (r:Entity {uuid:$u}) SET r.attributes = $a"
+
+	matched, unmatched, written := 0, 0, 0
+	start := time.Now()
+	for c := 0; maxChunks == 0 || c < maxChunks; c++ {
+		rows := query(ctx, d, selChunk, nil)
+		if len(rows) == 0 {
+			break
+		}
+		for _, row := range rows {
+			uuid, _ := row["uuid"].(string)
+			name, _ := row["name"].(string)
+			attrs, _ := row["attrs"].(string)
+			entry, ok := resolve(index, name, attrs)
+			if !ok {
+				unmatched++
+				if dryRun {
+					continue
+				}
+				// Mark as processed (empty-but-checked) so re-runs don't rescan it:
+				// flip "xrefs": [] to "xrefs":[] (compact) by rewriting attributes.
+				if newAttrs, changed := setXrefs(attrs, nil, nil); changed {
+					_, _, _, _ = d.ExecuteQuery(ctx, setQ, map[string]any{"u": uuid, "a": newAttrs})
+				}
+				continue
+			}
+			matched++
+			curie := toCURIE(entry)
+			url := toURL(entry)
+			if dryRun {
+				if matched <= 12 {
+					log.Printf("  %q -> %s  %s", name, curie, url)
+				}
+				continue
+			}
+			newAttrs, changed := setXrefs(attrs, []string{curie}, []string{url})
+			if !changed {
+				continue
+			}
+			if _, _, _, err := d.ExecuteQuery(ctx, setQ, map[string]any{"u": uuid, "a": newAttrs}); err != nil {
+				log.Printf("SET %s failed (skipping): %v", uuid, err)
+				continue
+			}
+			written++
+			if written%ckptEvery == 0 {
+				checkpoint(ctx, d)
+				el := time.Since(start).Seconds()
+				rate := float64(written) / el
+				log.Printf("%d written  %d matched  %d unmatched  %.0f/s", written, matched, unmatched, rate)
+			}
+		}
+		if dryRun {
+			log.Printf("dry-run chunk %d: %d matched, %d unmatched (no writes)", c, matched, unmatched)
+			break
+		}
+		checkpoint(ctx, d)
+		log.Printf("chunk %d complete: %d written, %d matched, %d unmatched", c, written, matched, unmatched)
+	}
+	if !dryRun {
+		checkpoint(ctx, d)
+	}
+	log.Printf("FINISHED: %d written, %d matched, %d unmatched of %d", written, matched, unmatched, total)
+}
+
+// resolve picks the PrimeKG entry for an entity name, disambiguating a colliding
+// name by matching the graph entity_type (from attributes) to PrimeKG's node_type.
+func resolve(index map[string][]pkgEntry, name, attrs string) (pkgEntry, bool) {
+	entries := index[strings.ToLower(strings.TrimSpace(name))]
+	if len(entries) == 0 {
+		return pkgEntry{}, false
+	}
+	if len(entries) == 1 {
+		return entries[0], true
+	}
+	want := normType(gjsonString(attrs, "entity_type"))
+	for _, e := range entries {
+		if want != "" && normType(e.ntype) == want {
+			return e, true
+		}
+	}
+	return entries[0], true // fall back to first; names collide for <0.1% of nodes
+}
+
+// setXrefs writes xrefs/source_urls into the attributes JSON, returning the new
+// string and whether it changed. Passing nil/empty still flips the empty-array
+// marker to compact form so the idempotency filter no longer matches the row.
+func setXrefs(attrs string, xrefs, urls []string) (string, bool) {
+	var m map[string]any
+	if err := json.Unmarshal([]byte(attrs), &m); err != nil || m == nil {
+		return attrs, false
+	}
+	if len(xrefs) > 0 {
+		m["xrefs"] = xrefs
+	} else {
+		m["xrefs"] = []string{}
+	}
+	if len(urls) > 0 {
+		m["source_urls"] = urls
+	}
+	out, err := json.Marshal(m)
+	if err != nil {
+		return attrs, false
+	}
+	s := string(out)
+	if s == attrs {
+		return attrs, false
+	}
+	return s, true
+}
+
+// gjsonString pulls a top-level string field out of a small JSON object without a
+// full typed struct (attributes is an open map).
+func gjsonString(js, key string) string {
+	var m map[string]any
+	if json.Unmarshal([]byte(js), &m) != nil {
+		return ""
+	}
+	if v, ok := m[key].(string); ok {
+		return v
+	}
+	return ""
+}
+
+func normType(s string) string {
+	s = strings.ToLower(strings.TrimSpace(s))
+	s = strings.ReplaceAll(s, " ", "_")
+	s = strings.ReplaceAll(s, "/", "_")
+	return s
+}
+
+// toCURIE renders the canonical compact identifier for an upstream reference.
+func toCURIE(e pkgEntry) string {
+	switch e.source {
+	case "GO":
+		return "GO:" + pad7(e.id)
+	case "MONDO", "MONDO_grouped":
+		return "MONDO:" + pad7(e.id)
+	case "HPO":
+		return "HP:" + pad7(e.id)
+	case "UBERON":
+		return "UBERON:" + pad7(e.id)
+	case "NCBI":
+		return "NCBIGene:" + e.id
+	case "DrugBank":
+		return "DrugBank:" + e.id
+	case "REACTOME":
+		return "Reactome:" + e.id
+	case "CTD":
+		return "CTD:" + e.id
+	default:
+		return e.source + ":" + e.id
+	}
+}
+
+// toURL renders a resolvable link to the upstream source record.
+func toURL(e pkgEntry) string {
+	switch e.source {
+	case "GO":
+		return "https://amigo.geneontology.org/amigo/term/GO:" + pad7(e.id)
+	case "MONDO", "MONDO_grouped":
+		return "https://monarchinitiative.org/MONDO:" + pad7(e.id)
+	case "HPO":
+		return "https://hpo.jax.org/app/browse/term/HP:" + pad7(e.id)
+	case "UBERON":
+		return "http://purl.obolibrary.org/obo/UBERON_" + pad7(e.id)
+	case "NCBI":
+		return "https://www.ncbi.nlm.nih.gov/gene/" + e.id
+	case "DrugBank":
+		return "https://go.drugbank.com/drugs/" + e.id
+	case "REACTOME":
+		return "https://reactome.org/content/detail/" + e.id
+	case "CTD":
+		return "https://ctdbase.org/detail.go?type=chem&acc=" + e.id
+	default:
+		return ""
+	}
+}
+
+// pad7 zero-pads a bare numeric ontology id to the conventional 7 digits
+// (GO 51581 -> 0051581); leaves non-numeric ids untouched.
+func pad7(id string) string {
+	for _, r := range id {
+		if r < '0' || r > '9' {
+			return id
+		}
+	}
+	if len(id) >= 7 {
+		return id
+	}
+	return strings.Repeat("0", 7-len(id)) + id
+}
+
+func count(ctx context.Context, d *driver.LadybugDriver, q string) int {
+	rows := query(ctx, d, q, nil)
+	if len(rows) == 0 {
+		return 0
+	}
+	switch v := rows[0]["c"].(type) {
+	case int64:
+		return int(v)
+	case int:
+		return v
+	case float64:
+		return int(v)
+	}
+	return 0
+}
+
+func query(ctx context.Context, d *driver.LadybugDriver, q string, params map[string]any) []map[string]any {
+	res, _, _, err := d.ExecuteQuery(ctx, q, params)
+	if err != nil {
+		log.Fatalf("query failed: %v\n%s", err, q)
+	}
+	rows, ok := res.([]map[string]any)
+	if !ok {
+		log.Fatalf("unexpected result type %T", res)
+	}
+	return rows
+}
+
+func checkpoint(ctx context.Context, d *driver.LadybugDriver) {
+	if _, _, _, err := d.ExecuteQuery(ctx, "CHECKPOINT", nil); err != nil {
+		log.Printf("checkpoint warning (driver flushes on close): %v", err)
+	}
+}

--- a/cmd/copy-name-embeddings/main.go
+++ b/cmd/copy-name-embeddings/main.go
@@ -1,0 +1,213 @@
+//go:build cgo && system_ladybug
+
+// copy-name-embeddings makes a generalization subgraph (G_g) self-sufficient for
+// embedding-based name resolution: it copies Entity.name_embedding from a fully
+// embedded source graph into the target G_g (joined by name — the G_g's canonical
+// names are a subset of the source's) and builds an HNSW vector index on the target.
+//
+// The G_g is emitted without embeddings (the generalization builder carries names +
+// relations only), so reasoning hosts otherwise have to open the large source graph
+// just to resolve a name. After this runs, the reasoner can resolve AND reason over
+// the same small graph. No re-embedding — the source vectors are reused verbatim, so
+// they stay in the same embedding space as the query embedder.
+//
+// Idempotent: only entities whose name_embedding is empty/wrong-dim are written, and
+// the index is (re)created at the end. Resumable — re-running resumes the remainder.
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/soundprediction/predicato/pkg/driver"
+)
+
+func main() {
+	srcPath := flag.String("src", "", "source graph with populated name_embedding (required)")
+	dstPath := flag.String("dst", "", "target generalization graph to fill + index (required)")
+	dims := flag.Int("dims", 1024, "embedding dimensions")
+	chunkSz := flag.Int("chunk", 50000, "entities pulled per target scan")
+	ckptEvery := flag.Int("checkpoint-every", 2000, "checkpoint every N writes")
+	bufBytes := flag.Uint64("buffer-pool-bytes", 6<<30, "ladybug buffer pool size")
+	skipIndex := flag.Bool("skip-index", false, "copy embeddings but do not create the vector index")
+	flag.Parse()
+	if *srcPath == "" || *dstPath == "" {
+		log.Fatal("--src and --dst are required")
+	}
+	ctx := context.Background()
+
+	index := loadSourceEmbeddings(ctx, *srcPath, *dims, *bufBytes)
+	log.Printf("loaded %d source name embeddings", len(index))
+	if len(index) == 0 {
+		log.Fatal("source graph has no name embeddings")
+	}
+
+	dcfg := driver.DefaultLadybugDriverConfig()
+	dcfg.DBPath = *dstPath
+	dcfg.ReadOnly = false
+	dcfg.BufferPoolSize = *bufBytes
+	d, err := driver.NewLadybugDriverWithConfig(dcfg)
+	if err != nil {
+		log.Fatalf("open dst %s: %v", *dstPath, err)
+	}
+	defer d.Close()
+
+	copyInto(ctx, d, index, *dims, *chunkSz, *ckptEvery)
+
+	if !*skipIndex {
+		createIndex(ctx, d)
+	}
+}
+
+// loadSourceEmbeddings reads name -> name_embedding from the source graph.
+func loadSourceEmbeddings(ctx context.Context, path string, dims int, buf uint64) map[string][]float32 {
+	cfg := driver.DefaultLadybugDriverConfig()
+	cfg.DBPath = path
+	cfg.ReadOnly = true
+	cfg.BufferPoolSize = buf
+	s, err := driver.NewLadybugDriverWithConfig(cfg)
+	if err != nil {
+		log.Fatalf("open src %s: %v", path, err)
+	}
+	defer s.Close()
+
+	rows := query(ctx, s, fmt.Sprintf(
+		"MATCH (n:Entity) WHERE size(n.name_embedding) = %d RETURN n.name AS name, n.name_embedding AS emb", dims), nil)
+	out := make(map[string][]float32, len(rows))
+	for _, r := range rows {
+		name, _ := r["name"].(string)
+		if strings.TrimSpace(name) == "" {
+			continue
+		}
+		vec := toFloat32(r["emb"])
+		if len(vec) != dims {
+			continue
+		}
+		out[strings.ToLower(strings.TrimSpace(name))] = vec
+	}
+	return out
+}
+
+func copyInto(ctx context.Context, d *driver.LadybugDriver, index map[string][]float32, dims, chunkSz, ckptEvery int) {
+	miss := fmt.Sprintf("(n.name_embedding IS NULL OR size(n.name_embedding) <> %d)", dims)
+	total := count(ctx, d, fmt.Sprintf("MATCH (n:Entity) WHERE %s RETURN count(n) AS c", miss))
+	log.Printf("%d target entities without a %d-dim embedding", total, dims)
+	selChunk := fmt.Sprintf("MATCH (n:Entity) WHERE %s RETURN n.uuid AS uuid, n.name AS name LIMIT %d", miss, chunkSz)
+	setQ := "MATCH (n:Entity {uuid:$u}) SET n.name_embedding = $vec"
+
+	written, matched := 0, 0
+	start := time.Now()
+	for {
+		rows := query(ctx, d, selChunk, nil)
+		if len(rows) == 0 {
+			break
+		}
+		progressed := false
+		for _, r := range rows {
+			uuid, _ := r["uuid"].(string)
+			name, _ := r["name"].(string)
+			vec, ok := index[strings.ToLower(strings.TrimSpace(name))]
+			if !ok {
+				continue // no source vector for this name; leave empty (drops out next scan? no — keep marker)
+			}
+			matched++
+			if _, _, _, err := d.ExecuteQuery(ctx, setQ, map[string]any{"u": uuid, "vec": vec}); err != nil {
+				log.Printf("SET %s failed: %v", uuid, err)
+				continue
+			}
+			written++
+			progressed = true
+			if written%ckptEvery == 0 {
+				checkpoint(ctx, d)
+				log.Printf("%d written  %d matched  %.0f/s", written, matched, float64(written)/time.Since(start).Seconds())
+			}
+		}
+		checkpoint(ctx, d)
+		// If a whole chunk produced no writes, the remaining rows are all unmatched —
+		// they would re-appear forever (still empty), so stop.
+		if !progressed {
+			log.Printf("chunk had no source matches; %d entities have no source embedding", len(rows))
+			break
+		}
+	}
+	checkpoint(ctx, d)
+	log.Printf("COPY DONE: %d embeddings written (%d names matched)", written, matched)
+}
+
+func createIndex(ctx context.Context, d *driver.LadybugDriver) {
+	if _, _, _, err := d.ExecuteQuery(ctx, "LOAD EXTENSION 'vector'", nil); err != nil {
+		log.Printf("LOAD vector warning: %v", err)
+	}
+	log.Printf("creating HNSW index name_emb_idx on Entity.name_embedding …")
+	if _, _, _, err := d.ExecuteQuery(ctx, "CALL CREATE_VECTOR_INDEX('Entity', 'name_emb_idx', 'name_embedding')", nil); err != nil {
+		log.Fatalf("CREATE_VECTOR_INDEX failed: %v", err)
+	}
+	checkpoint(ctx, d)
+	log.Printf("INDEX CREATED")
+}
+
+func toFloat32(v any) []float32 {
+	switch t := v.(type) {
+	case []float32:
+		return t
+	case []float64:
+		out := make([]float32, len(t))
+		for i, f := range t {
+			out[i] = float32(f)
+		}
+		return out
+	case []any:
+		out := make([]float32, 0, len(t))
+		for _, e := range t {
+			switch f := e.(type) {
+			case float32:
+				out = append(out, f)
+			case float64:
+				out = append(out, float32(f))
+			default:
+				return nil
+			}
+		}
+		return out
+	default:
+		return nil
+	}
+}
+
+func count(ctx context.Context, d *driver.LadybugDriver, q string) int {
+	rows := query(ctx, d, q, nil)
+	if len(rows) == 0 {
+		return 0
+	}
+	switch v := rows[0]["c"].(type) {
+	case int64:
+		return int(v)
+	case int:
+		return v
+	case float64:
+		return int(v)
+	}
+	return 0
+}
+
+func query(ctx context.Context, d *driver.LadybugDriver, q string, params map[string]any) []map[string]any {
+	res, _, _, err := d.ExecuteQuery(ctx, q, params)
+	if err != nil {
+		log.Fatalf("query failed: %v\n%s", err, q)
+	}
+	rows, ok := res.([]map[string]any)
+	if !ok {
+		log.Fatalf("unexpected result type %T", res)
+	}
+	return rows
+}
+
+func checkpoint(ctx context.Context, d *driver.LadybugDriver) {
+	if _, _, _, err := d.ExecuteQuery(ctx, "CHECKPOINT", nil); err != nil {
+		log.Printf("checkpoint warning: %v", err)
+	}
+}

--- a/cmd/lbug.h
+++ b/cmd/lbug.h
@@ -1,0 +1,1687 @@
+#pragma once
+#include <stdbool.h>
+#include <stdint.h>
+#include <time.h>
+#ifdef _WIN32
+#include <windows.h>
+#endif
+
+/* Export header from common/api.h */
+// Helpers
+#if defined _WIN32 || defined __CYGWIN__
+#define LBUG_HELPER_DLL_IMPORT __declspec(dllimport)
+#define LBUG_HELPER_DLL_EXPORT __declspec(dllexport)
+#define LBUG_HELPER_DLL_LOCAL
+#define LBUG_HELPER_DEPRECATED __declspec(deprecated)
+#else
+#define LBUG_HELPER_DLL_IMPORT __attribute__((visibility("default")))
+#define LBUG_HELPER_DLL_EXPORT __attribute__((visibility("default")))
+#define LBUG_HELPER_DLL_LOCAL __attribute__((visibility("hidden")))
+#define LBUG_HELPER_DEPRECATED __attribute__((__deprecated__))
+#endif
+
+#ifdef LBUG_STATIC_DEFINE
+#define LBUG_API
+#define LBUG_NO_EXPORT
+#else
+#ifndef LBUG_API
+#ifdef LBUG_EXPORTS
+/* We are building this library */
+#define LBUG_API LBUG_HELPER_DLL_EXPORT
+#else
+/* We are using this library */
+#define LBUG_API LBUG_HELPER_DLL_IMPORT
+#endif
+#endif
+
+#endif
+
+#ifndef LBUG_DEPRECATED
+#define LBUG_DEPRECATED LBUG_HELPER_DEPRECATED
+#endif
+
+#ifndef LBUG_DEPRECATED_EXPORT
+#define LBUG_DEPRECATED_EXPORT LBUG_API LBUG_DEPRECATED
+#endif
+/* end export header */
+
+// The Arrow C data interface.
+// https://arrow.apache.org/docs/format/CDataInterface.html
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef ARROW_C_DATA_INTERFACE
+#define ARROW_C_DATA_INTERFACE
+
+#define ARROW_FLAG_DICTIONARY_ORDERED 1
+#define ARROW_FLAG_NULLABLE 2
+#define ARROW_FLAG_MAP_KEYS_SORTED 4
+
+struct ArrowSchema {
+    // Array type description
+    const char* format;
+    const char* name;
+    const char* metadata;
+    int64_t flags;
+    int64_t n_children;
+    struct ArrowSchema** children;
+    struct ArrowSchema* dictionary;
+
+    // Release callback
+    void (*release)(struct ArrowSchema*);
+    // Opaque producer-specific data
+    void* private_data;
+};
+
+struct ArrowArray {
+    // Array data description
+    int64_t length;
+    int64_t null_count;
+    int64_t offset;
+    int64_t n_buffers;
+    int64_t n_children;
+    const void** buffers;
+    struct ArrowArray** children;
+    struct ArrowArray* dictionary;
+
+    // Release callback
+    void (*release)(struct ArrowArray*);
+    // Opaque producer-specific data
+    void* private_data;
+};
+
+#endif // ARROW_C_DATA_INTERFACE
+
+#ifdef __cplusplus
+}
+#endif
+
+#ifdef __cplusplus
+#define LBUG_C_API extern "C" LBUG_API
+#else
+#define LBUG_C_API LBUG_API
+#endif
+
+/**
+ * @brief Stores runtime configuration for creating or opening a Database
+ */
+typedef struct {
+    // bufferPoolSize Max size of the buffer pool in bytes.
+    // The larger the buffer pool, the more data from the database files is kept in memory,
+    // reducing the amount of File I/O
+    uint64_t buffer_pool_size;
+    // The maximum number of threads to use during query execution
+    uint64_t max_num_threads;
+    // Whether or not to compress data on-disk for supported types
+    bool enable_compression;
+    // If true, open the database in read-only mode. No write transaction is allowed on the Database
+    // object. If false, open the database read-write.
+    bool read_only;
+    //  The maximum size of the database in bytes. Note that this is introduced temporarily for now
+    //  to get around with the default 8TB mmap address space limit under some environment. This
+    //  will be removed once we implemente a better solution later. The value is default to 1 << 43
+    //  (8TB) under 64-bit environment and 1GB under 32-bit one (see `DEFAULT_VM_REGION_MAX_SIZE`).
+    uint64_t max_db_size;
+    // If true, the database will automatically checkpoint when the size of
+    // the WAL file exceeds the checkpoint threshold.
+    bool auto_checkpoint;
+    // The threshold of the WAL file size in bytes. When the size of the
+    // WAL file exceeds this threshold, the database will checkpoint if auto_checkpoint is true.
+    uint64_t checkpoint_threshold;
+    // If true, any WAL replay failure when loading the database will raise an error.
+    bool throw_on_wal_replay_failure;
+    // If true, checksums are enabled for WAL and storage pages.
+    bool enable_checksums;
+    // If true, multiple concurrent write transactions are allowed.
+    bool enable_multi_writes;
+    // If true, node tables create the default primary-key hash index.
+    bool enable_default_hash_index;
+
+#if defined(__APPLE__)
+    // The thread quality of service (QoS) for the worker threads.
+    // This works for Swift bindings on Apple platforms only.
+    uint32_t thread_qos;
+#endif
+} lbug_system_config;
+
+/**
+ * @brief lbug_database manages all database components.
+ */
+typedef struct {
+    void* _database;
+} lbug_database;
+
+/**
+ * @brief lbug_connection is used to interact with a Database instance. Each connection is
+ * thread-safe. Multiple connections can connect to the same Database instance in a multi-threaded
+ * environment.
+ */
+typedef struct {
+    void* _connection;
+} lbug_connection;
+
+/**
+ * @brief lbug_prepared_statement is a parameterized query which can avoid planning the same query
+ * for repeated execution.
+ */
+typedef struct {
+    void* _prepared_statement;
+    void* _bound_values;
+} lbug_prepared_statement;
+
+/**
+ * @brief lbug_query_result stores the result of a query.
+ */
+typedef struct {
+    void* _query_result;
+    bool _is_owned_by_cpp;
+} lbug_query_result;
+
+/**
+ * @brief lbug_flat_tuple stores a vector of values.
+ */
+typedef struct {
+    void* _flat_tuple;
+    bool _is_owned_by_cpp;
+} lbug_flat_tuple;
+
+/**
+ * @brief lbug_logical_type is the lbug internal representation of data types.
+ */
+typedef struct {
+    void* _data_type;
+} lbug_logical_type;
+
+/**
+ * @brief lbug_value is used to represent a value with any lbug internal dataType.
+ */
+typedef struct {
+    void* _value;
+    bool _is_owned_by_cpp;
+} lbug_value;
+
+/**
+ * @brief lbug internal internal_id type which stores the table_id and offset of a node/rel.
+ */
+typedef struct {
+    uint64_t table_id;
+    uint64_t offset;
+} lbug_internal_id_t;
+
+/**
+ * @brief lbug internal date type which stores the number of days since 1970-01-01 00:00:00 UTC.
+ */
+typedef struct {
+    // Days since 1970-01-01 00:00:00 UTC.
+    int32_t days;
+} lbug_date_t;
+
+/**
+ * @brief lbug internal timestamp_ns type which stores the number of nanoseconds since 1970-01-01
+ * 00:00:00 UTC.
+ */
+typedef struct {
+    // Nanoseconds since 1970-01-01 00:00:00 UTC.
+    int64_t value;
+} lbug_timestamp_ns_t;
+
+/**
+ * @brief lbug internal timestamp_ms type which stores the number of milliseconds since 1970-01-01
+ * 00:00:00 UTC.
+ */
+typedef struct {
+    // Milliseconds since 1970-01-01 00:00:00 UTC.
+    int64_t value;
+} lbug_timestamp_ms_t;
+
+/**
+ * @brief lbug internal timestamp_sec_t type which stores the number of seconds since 1970-01-01
+ * 00:00:00 UTC.
+ */
+typedef struct {
+    // Seconds since 1970-01-01 00:00:00 UTC.
+    int64_t value;
+} lbug_timestamp_sec_t;
+
+/**
+ * @brief lbug internal timestamp_tz type which stores the number of microseconds since 1970-01-01
+ * with timezone 00:00:00 UTC.
+ */
+typedef struct {
+    // Microseconds since 1970-01-01 00:00:00 UTC.
+    int64_t value;
+} lbug_timestamp_tz_t;
+
+/**
+ * @brief lbug internal timestamp type which stores the number of microseconds since 1970-01-01
+ * 00:00:00 UTC.
+ */
+typedef struct {
+    // Microseconds since 1970-01-01 00:00:00 UTC.
+    int64_t value;
+} lbug_timestamp_t;
+
+/**
+ * @brief lbug internal interval type which stores the months, days and microseconds.
+ */
+typedef struct {
+    int32_t months;
+    int32_t days;
+    int64_t micros;
+} lbug_interval_t;
+
+/**
+ * @brief lbug_query_summary stores the execution time, plan, compiling time and query options of a
+ * query.
+ */
+typedef struct {
+    void* _query_summary;
+} lbug_query_summary;
+
+typedef struct {
+    uint64_t low;
+    int64_t high;
+} lbug_int128_t;
+
+/**
+ * @brief enum class for lbug internal dataTypes.
+ */
+typedef enum {
+    LBUG_ANY = 0,
+    LBUG_NODE = 10,
+    LBUG_REL = 11,
+    LBUG_RECURSIVE_REL = 12,
+    // SERIAL is a special data type that is used to represent a sequence of INT64 values that are
+    // incremented by 1 starting from 0.
+    LBUG_SERIAL = 13,
+    // fixed size types
+    LBUG_BOOL = 22,
+    LBUG_INT64 = 23,
+    LBUG_INT32 = 24,
+    LBUG_INT16 = 25,
+    LBUG_INT8 = 26,
+    LBUG_UINT64 = 27,
+    LBUG_UINT32 = 28,
+    LBUG_UINT16 = 29,
+    LBUG_UINT8 = 30,
+    LBUG_INT128 = 31,
+    LBUG_DOUBLE = 32,
+    LBUG_FLOAT = 33,
+    LBUG_DATE = 34,
+    LBUG_TIMESTAMP = 35,
+    LBUG_TIMESTAMP_SEC = 36,
+    LBUG_TIMESTAMP_MS = 37,
+    LBUG_TIMESTAMP_NS = 38,
+    LBUG_TIMESTAMP_TZ = 39,
+    LBUG_INTERVAL = 40,
+    LBUG_DECIMAL = 41,
+    LBUG_INTERNAL_ID = 42,
+    // variable size types
+    LBUG_STRING = 50,
+    LBUG_BLOB = 51,
+    LBUG_LIST = 52,
+    LBUG_ARRAY = 53,
+    LBUG_STRUCT = 54,
+    LBUG_MAP = 55,
+    LBUG_UNION = 56,
+    LBUG_POINTER = 58,
+    LBUG_UUID = 59
+} lbug_data_type_id;
+
+/**
+ * @brief enum class for lbug function return state.
+ */
+typedef enum { LbugSuccess = 0, LbugError = 1 } lbug_state;
+
+// Database
+/**
+ * @brief Allocates memory and creates a lbug database instance at database_path with
+ * bufferPoolSize=buffer_pool_size. Caller is responsible for calling lbug_database_destroy() to
+ * release the allocated memory.
+ * @param database_path The path to the database.
+ * @param system_config The runtime configuration for creating or opening the database.
+ * @param[out] out_database The output parameter that will hold the database instance.
+ * @return The state indicating the success or failure of the operation.
+ */
+LBUG_C_API lbug_state lbug_database_init(const char* database_path,
+    lbug_system_config system_config, lbug_database* out_database);
+/**
+ * @brief Destroys the lbug database instance and frees the allocated memory.
+ * @param database The database instance to destroy.
+ */
+LBUG_C_API void lbug_database_destroy(lbug_database* database);
+
+LBUG_C_API lbug_system_config lbug_default_system_config();
+
+// Connection
+/**
+ * @brief Allocates memory and creates a connection to the database. Caller is responsible for
+ * calling lbug_connection_destroy() to release the allocated memory.
+ * @param database The database instance to connect to.
+ * @param[out] out_connection The output parameter that will hold the connection instance.
+ * @return The state indicating the success or failure of the operation.
+ */
+LBUG_C_API lbug_state lbug_connection_init(lbug_database* database,
+    lbug_connection* out_connection);
+/**
+ * @brief Destroys the connection instance and frees the allocated memory.
+ * @param connection The connection instance to destroy.
+ */
+LBUG_C_API void lbug_connection_destroy(lbug_connection* connection);
+/**
+ * @brief Sets the maximum number of threads to use for executing queries.
+ * @param connection The connection instance to set max number of threads for execution.
+ * @param num_threads The maximum number of threads to use for executing queries.
+ * @return The state indicating the success or failure of the operation.
+ */
+LBUG_C_API lbug_state lbug_connection_set_max_num_thread_for_exec(lbug_connection* connection,
+    uint64_t num_threads);
+
+/**
+ * @brief Returns the maximum number of threads of the connection to use for executing queries.
+ * @param connection The connection instance to return max number of threads for execution.
+ * @param[out] out_result The output parameter that will hold the maximum number of threads to use
+ * for executing queries.
+ * @return The state indicating the success or failure of the operation.
+ */
+LBUG_C_API lbug_state lbug_connection_get_max_num_thread_for_exec(lbug_connection* connection,
+    uint64_t* out_result);
+/**
+ * @brief Executes the given query and returns the result.
+ * @param connection The connection instance to execute the query.
+ * @param query The query to execute.
+ * @param[out] out_query_result The output parameter that will hold the result of the query.
+ * @return The state indicating the success or failure of the operation.
+ */
+LBUG_C_API lbug_state lbug_connection_query(lbug_connection* connection, const char* query,
+    lbug_query_result* out_query_result);
+/**
+ * @brief Prepares the given query and returns the prepared statement.
+ * @param connection The connection instance to prepare the query.
+ * @param query The query to prepare.
+ * @param[out] out_prepared_statement The output parameter that will hold the prepared statement.
+ * @return The state indicating the success or failure of the operation.
+ */
+LBUG_C_API lbug_state lbug_connection_prepare(lbug_connection* connection, const char* query,
+    lbug_prepared_statement* out_prepared_statement);
+/**
+ * @brief Executes the prepared_statement using connection.
+ * @param connection The connection instance to execute the prepared_statement.
+ * @param prepared_statement The prepared statement to execute.
+ * @param[out] out_query_result The output parameter that will hold the result of the query.
+ * @return The state indicating the success or failure of the operation.
+ */
+LBUG_C_API lbug_state lbug_connection_execute(lbug_connection* connection,
+    lbug_prepared_statement* prepared_statement, lbug_query_result* out_query_result);
+/**
+ * @brief Creates an Arrow memory-backed node table from Arrow C Data Interface data.
+ *
+ * Ownership of schema and arrays is transferred to lbug on success or failure. The caller must not
+ * release them after this call.
+ */
+LBUG_C_API lbug_state lbug_connection_create_arrow_table(lbug_connection* connection,
+    const char* table_name, struct ArrowSchema* schema, struct ArrowArray* arrays,
+    uint64_t num_arrays, lbug_query_result* out_query_result);
+/**
+ * @brief Creates an Arrow memory-backed relationship table from Arrow C Data Interface data.
+ *
+ * The Arrow table must contain endpoint columns named "from" and "to". Ownership of schema and
+ * arrays is transferred to lbug on success or failure. The caller must not release them after this
+ * call.
+ */
+LBUG_C_API lbug_state lbug_connection_create_arrow_rel_table(lbug_connection* connection,
+    const char* table_name, const char* src_table_name, const char* dst_table_name,
+    struct ArrowSchema* schema, struct ArrowArray* arrays, uint64_t num_arrays,
+    lbug_query_result* out_query_result);
+/**
+ * @brief Creates a CSR Arrow memory-backed relationship table from Arrow C Data Interface data.
+ *
+ * The indices Arrow table must contain a destination offset column and any relationship property
+ * columns. The indptr Arrow table must contain one offset column. Ownership of schemas and arrays
+ * is transferred to lbug on success or failure. The caller must not release them after this call.
+ *
+ * @param dst_col_name Name of the destination offset column in the indices table. If NULL,
+ *                     defaults to "to".
+ */
+LBUG_C_API lbug_state lbug_connection_create_arrow_rel_table_csr(lbug_connection* connection,
+    const char* table_name, const char* src_table_name, const char* dst_table_name,
+    struct ArrowSchema* indices_schema, struct ArrowArray* indices_arrays,
+    uint64_t num_indices_arrays, struct ArrowSchema* indptr_schema,
+    struct ArrowArray* indptr_arrays, uint64_t num_indptr_arrays, const char* dst_col_name,
+    lbug_query_result* out_query_result);
+/**
+ * @brief Drops an Arrow memory-backed table.
+ */
+LBUG_C_API lbug_state lbug_connection_drop_arrow_table(lbug_connection* connection,
+    const char* table_name, lbug_query_result* out_query_result);
+/**
+ * @brief Interrupts the current query execution in the connection.
+ * @param connection The connection instance to interrupt.
+ */
+LBUG_C_API void lbug_connection_interrupt(lbug_connection* connection);
+/**
+ * @brief Sets query timeout value in milliseconds for the connection.
+ * @param connection The connection instance to set query timeout value.
+ * @param timeout_in_ms The timeout value in milliseconds.
+ * @return The state indicating the success or failure of the operation.
+ */
+LBUG_C_API lbug_state lbug_connection_set_query_timeout(lbug_connection* connection,
+    uint64_t timeout_in_ms);
+
+// PreparedStatement
+/**
+ * @brief Destroys the prepared statement instance and frees the allocated memory.
+ * @param prepared_statement The prepared statement instance to destroy.
+ */
+LBUG_C_API void lbug_prepared_statement_destroy(lbug_prepared_statement* prepared_statement);
+/**
+ * @return the query is prepared successfully or not.
+ */
+LBUG_C_API bool lbug_prepared_statement_is_success(lbug_prepared_statement* prepared_statement);
+/**
+ * @return true if the prepared statement only performs read operations.
+ */
+LBUG_C_API bool lbug_prepared_statement_is_read_only(lbug_prepared_statement* prepared_statement);
+/**
+ * @brief Returns the error message if the prepared statement is not prepared successfully.
+ * The caller is responsible for freeing the returned string with `lbug_destroy_string`.
+ * @param prepared_statement The prepared statement instance.
+ * @return the error message if the statement is not prepared successfully or null
+ * if the statement is prepared successfully.
+ */
+LBUG_C_API char* lbug_prepared_statement_get_error_message(
+    lbug_prepared_statement* prepared_statement);
+/**
+ * @brief Binds the given boolean value to the given parameter name in the prepared statement.
+ * @param prepared_statement The prepared statement instance to bind the value.
+ * @param param_name The parameter name to bind the value.
+ * @param value The boolean value to bind.
+ * @return The state indicating the success or failure of the operation.
+ */
+LBUG_C_API lbug_state lbug_prepared_statement_bind_bool(lbug_prepared_statement* prepared_statement,
+    const char* param_name, bool value);
+/**
+ * @brief Binds the given int64_t value to the given parameter name in the prepared statement.
+ * @param prepared_statement The prepared statement instance to bind the value.
+ * @param param_name The parameter name to bind the value.
+ * @param value The int64_t value to bind.
+ * @return The state indicating the success or failure of the operation.
+ */
+LBUG_C_API lbug_state lbug_prepared_statement_bind_int64(
+    lbug_prepared_statement* prepared_statement, const char* param_name, int64_t value);
+/**
+ * @brief Binds the given int32_t value to the given parameter name in the prepared statement.
+ * @param prepared_statement The prepared statement instance to bind the value.
+ * @param param_name The parameter name to bind the value.
+ * @param value The int32_t value to bind.
+ * @return The state indicating the success or failure of the operation.
+ */
+LBUG_C_API lbug_state lbug_prepared_statement_bind_int32(
+    lbug_prepared_statement* prepared_statement, const char* param_name, int32_t value);
+/**
+ * @brief Binds the given int16_t value to the given parameter name in the prepared statement.
+ * @param prepared_statement The prepared statement instance to bind the value.
+ * @param param_name The parameter name to bind the value.
+ * @param value The int16_t value to bind.
+ * @return The state indicating the success or failure of the operation.
+ */
+LBUG_C_API lbug_state lbug_prepared_statement_bind_int16(
+    lbug_prepared_statement* prepared_statement, const char* param_name, int16_t value);
+/**
+ * @brief Binds the given int8_t value to the given parameter name in the prepared statement.
+ * @param prepared_statement The prepared statement instance to bind the value.
+ * @param param_name The parameter name to bind the value.
+ * @param value The int8_t value to bind.
+ * @return The state indicating the success or failure of the operation.
+ */
+LBUG_C_API lbug_state lbug_prepared_statement_bind_int8(lbug_prepared_statement* prepared_statement,
+    const char* param_name, int8_t value);
+/**
+ * @brief Binds the given uint64_t value to the given parameter name in the prepared statement.
+ * @param prepared_statement The prepared statement instance to bind the value.
+ * @param param_name The parameter name to bind the value.
+ * @param value The uint64_t value to bind.
+ * @return The state indicating the success or failure of the operation.
+ */
+LBUG_C_API lbug_state lbug_prepared_statement_bind_uint64(
+    lbug_prepared_statement* prepared_statement, const char* param_name, uint64_t value);
+/**
+ * @brief Binds the given uint32_t value to the given parameter name in the prepared statement.
+ * @param prepared_statement The prepared statement instance to bind the value.
+ * @param param_name The parameter name to bind the value.
+ * @param value The uint32_t value to bind.
+ * @return The state indicating the success or failure of the operation.
+ */
+LBUG_C_API lbug_state lbug_prepared_statement_bind_uint32(
+    lbug_prepared_statement* prepared_statement, const char* param_name, uint32_t value);
+/**
+ * @brief Binds the given uint16_t value to the given parameter name in the prepared statement.
+ * @param prepared_statement The prepared statement instance to bind the value.
+ * @param param_name The parameter name to bind the value.
+ * @param value The uint16_t value to bind.
+ * @return The state indicating the success or failure of the operation.
+ */
+LBUG_C_API lbug_state lbug_prepared_statement_bind_uint16(
+    lbug_prepared_statement* prepared_statement, const char* param_name, uint16_t value);
+/**
+ * @brief Binds the given int8_t value to the given parameter name in the prepared statement.
+ * @param prepared_statement The prepared statement instance to bind the value.
+ * @param param_name The parameter name to bind the value.
+ * @param value The int8_t value to bind.
+ * @return The state indicating the success or failure of the operation.
+ */
+LBUG_C_API lbug_state lbug_prepared_statement_bind_uint8(
+    lbug_prepared_statement* prepared_statement, const char* param_name, uint8_t value);
+
+/**
+ * @brief Binds the given double value to the given parameter name in the prepared statement.
+ * @param prepared_statement The prepared statement instance to bind the value.
+ * @param param_name The parameter name to bind the value.
+ * @param value The double value to bind.
+ * @return The state indicating the success or failure of the operation.
+ */
+LBUG_C_API lbug_state lbug_prepared_statement_bind_double(
+    lbug_prepared_statement* prepared_statement, const char* param_name, double value);
+/**
+ * @brief Binds the given float value to the given parameter name in the prepared statement.
+ * @param prepared_statement The prepared statement instance to bind the value.
+ * @param param_name The parameter name to bind the value.
+ * @param value The float value to bind.
+ * @return The state indicating the success or failure of the operation.
+ */
+LBUG_C_API lbug_state lbug_prepared_statement_bind_float(
+    lbug_prepared_statement* prepared_statement, const char* param_name, float value);
+/**
+ * @brief Binds the given date value to the given parameter name in the prepared statement.
+ * @param prepared_statement The prepared statement instance to bind the value.
+ * @param param_name The parameter name to bind the value.
+ * @param value The date value to bind.
+ * @return The state indicating the success or failure of the operation.
+ */
+LBUG_C_API lbug_state lbug_prepared_statement_bind_date(lbug_prepared_statement* prepared_statement,
+    const char* param_name, lbug_date_t value);
+/**
+ * @brief Binds the given timestamp_ns value to the given parameter name in the prepared statement.
+ * @param prepared_statement The prepared statement instance to bind the value.
+ * @param param_name The parameter name to bind the value.
+ * @param value The timestamp_ns value to bind.
+ * @return The state indicating the success or failure of the operation.
+ */
+LBUG_C_API lbug_state lbug_prepared_statement_bind_timestamp_ns(
+    lbug_prepared_statement* prepared_statement, const char* param_name, lbug_timestamp_ns_t value);
+/**
+ * @brief Binds the given timestamp_sec value to the given parameter name in the prepared statement.
+ * @param prepared_statement The prepared statement instance to bind the value.
+ * @param param_name The parameter name to bind the value.
+ * @param value The timestamp_sec value to bind.
+ * @return The state indicating the success or failure of the operation.
+ */
+LBUG_C_API lbug_state lbug_prepared_statement_bind_timestamp_sec(
+    lbug_prepared_statement* prepared_statement, const char* param_name,
+    lbug_timestamp_sec_t value);
+/**
+ * @brief Binds the given timestamp_tz value to the given parameter name in the prepared statement.
+ * @param prepared_statement The prepared statement instance to bind the value.
+ * @param param_name The parameter name to bind the value.
+ * @param value The timestamp_tz value to bind.
+ * @return The state indicating the success or failure of the operation.
+ */
+LBUG_C_API lbug_state lbug_prepared_statement_bind_timestamp_tz(
+    lbug_prepared_statement* prepared_statement, const char* param_name, lbug_timestamp_tz_t value);
+/**
+ * @brief Binds the given timestamp_ms value to the given parameter name in the prepared statement.
+ * @param prepared_statement The prepared statement instance to bind the value.
+ * @param param_name The parameter name to bind the value.
+ * @param value The timestamp_ms value to bind.
+ * @return The state indicating the success or failure of the operation.
+ */
+LBUG_C_API lbug_state lbug_prepared_statement_bind_timestamp_ms(
+    lbug_prepared_statement* prepared_statement, const char* param_name, lbug_timestamp_ms_t value);
+/**
+ * @brief Binds the given timestamp value to the given parameter name in the prepared statement.
+ * @param prepared_statement The prepared statement instance to bind the value.
+ * @param param_name The parameter name to bind the value.
+ * @param value The timestamp value to bind.
+ * @return The state indicating the success or failure of the operation.
+ */
+LBUG_C_API lbug_state lbug_prepared_statement_bind_timestamp(
+    lbug_prepared_statement* prepared_statement, const char* param_name, lbug_timestamp_t value);
+/**
+ * @brief Binds the given interval value to the given parameter name in the prepared statement.
+ * @param prepared_statement The prepared statement instance to bind the value.
+ * @param param_name The parameter name to bind the value.
+ * @param value The interval value to bind.
+ * @return The state indicating the success or failure of the operation.
+ */
+LBUG_C_API lbug_state lbug_prepared_statement_bind_interval(
+    lbug_prepared_statement* prepared_statement, const char* param_name, lbug_interval_t value);
+/**
+ * @brief Binds the given string value to the given parameter name in the prepared statement.
+ * @param prepared_statement The prepared statement instance to bind the value.
+ * @param param_name The parameter name to bind the value.
+ * @param value The string value to bind.
+ * @return The state indicating the success or failure of the operation.
+ */
+LBUG_C_API lbug_state lbug_prepared_statement_bind_string(
+    lbug_prepared_statement* prepared_statement, const char* param_name, const char* value);
+/**
+ * @brief Binds the given lbug value to the given parameter name in the prepared statement.
+ * @param prepared_statement The prepared statement instance to bind the value.
+ * @param param_name The parameter name to bind the value.
+ * @param value The lbug value to bind.
+ * @return The state indicating the success or failure of the operation.
+ */
+LBUG_C_API lbug_state lbug_prepared_statement_bind_value(
+    lbug_prepared_statement* prepared_statement, const char* param_name, lbug_value* value);
+
+// QueryResult
+/**
+ * @brief Destroys the given query result instance.
+ * @param query_result The query result instance to destroy.
+ */
+LBUG_C_API void lbug_query_result_destroy(lbug_query_result* query_result);
+/**
+ * @brief Returns true if the query is executed successful, false otherwise.
+ * @param query_result The query result instance to check.
+ */
+LBUG_C_API bool lbug_query_result_is_success(lbug_query_result* query_result);
+/**
+ * @brief Returns the error message if the query is failed.
+ * The caller is responsible for freeing the returned string with `lbug_destroy_string`.
+ * @param query_result The query result instance to check and return error message.
+ * @return The error message if the query has failed, or null if the query is successful.
+ */
+LBUG_C_API char* lbug_query_result_get_error_message(lbug_query_result* query_result);
+/**
+ * @brief Returns the number of columns in the query result.
+ * @param query_result The query result instance to return.
+ */
+LBUG_C_API uint64_t lbug_query_result_get_num_columns(lbug_query_result* query_result);
+/**
+ * @brief Returns the column name at the given index.
+ * @param query_result The query result instance to return.
+ * @param index The index of the column to return name.
+ * @param[out] out_column_name The output parameter that will hold the column name.
+ * @return The state indicating the success or failure of the operation.
+ */
+LBUG_C_API lbug_state lbug_query_result_get_column_name(lbug_query_result* query_result,
+    uint64_t index, char** out_column_name);
+/**
+ * @brief Returns the data type of the column at the given index.
+ * @param query_result The query result instance to return.
+ * @param index The index of the column to return data type.
+ * @param[out] out_column_data_type The output parameter that will hold the column data type.
+ * @return The state indicating the success or failure of the operation.
+ */
+LBUG_C_API lbug_state lbug_query_result_get_column_data_type(lbug_query_result* query_result,
+    uint64_t index, lbug_logical_type* out_column_data_type);
+/**
+ * @brief Returns the number of tuples in the query result.
+ * @param query_result The query result instance to return.
+ */
+LBUG_C_API uint64_t lbug_query_result_get_num_tuples(lbug_query_result* query_result);
+/**
+ * @brief Returns the query summary of the query result.
+ * @param query_result The query result instance to return.
+ * @param[out] out_query_summary The output parameter that will hold the query summary.
+ * @return The state indicating the success or failure of the operation.
+ */
+LBUG_C_API lbug_state lbug_query_result_get_query_summary(lbug_query_result* query_result,
+    lbug_query_summary* out_query_summary);
+/**
+ * @brief Returns true if we have not consumed all tuples in the query result, false otherwise.
+ * @param query_result The query result instance to check.
+ */
+LBUG_C_API bool lbug_query_result_has_next(lbug_query_result* query_result);
+/**
+ * @brief Returns the next tuple in the query result. Throws an exception if there is no more tuple.
+ * Note that to reduce resource allocation, all calls to lbug_query_result_get_next() reuse the same
+ * FlatTuple object. Since its contents will be overwritten, please complete processing a FlatTuple
+ * or make a copy of its data before calling lbug_query_result_get_next() again.
+ * @param query_result The query result instance to return.
+ * @param[out] out_flat_tuple The output parameter that will hold the next tuple.
+ * @return The state indicating the success or failure of the operation.
+ */
+LBUG_C_API lbug_state lbug_query_result_get_next(lbug_query_result* query_result,
+    lbug_flat_tuple* out_flat_tuple);
+/**
+ * @brief Returns true if we have not consumed all query results, false otherwise. Use this function
+ * for loop results of multiple query statements
+ * @param query_result The query result instance to check.
+ */
+LBUG_C_API bool lbug_query_result_has_next_query_result(lbug_query_result* query_result);
+/**
+ * @brief Returns the next query result. Use this function to loop multiple query statements'
+ * results.
+ * @param query_result The query result instance to return.
+ * @param[out] out_next_query_result The output parameter that will hold the next query result.
+ * @return The state indicating the success or failure of the operation.
+ */
+LBUG_C_API lbug_state lbug_query_result_get_next_query_result(lbug_query_result* query_result,
+    lbug_query_result* out_next_query_result);
+
+/**
+ * @brief Returns the query result as a string.
+ * @param query_result The query result instance to return.
+ * @return The query result as a string.
+ */
+LBUG_C_API char* lbug_query_result_to_string(lbug_query_result* query_result);
+/**
+ * @brief Resets the iterator of the query result to the beginning of the query result.
+ * @param query_result The query result instance to reset iterator.
+ */
+LBUG_C_API void lbug_query_result_reset_iterator(lbug_query_result* query_result);
+
+/**
+ * @brief Returns the query result's schema as ArrowSchema.
+ * @param query_result The query result instance to return.
+ * @param[out] out_schema The output parameter that will hold the datatypes of the columns as an
+ * arrow schema.
+ * @return The state indicating the success or failure of the operation.
+ *
+ * It is the caller's responsibility to call the release function to release the underlying data
+ */
+LBUG_C_API lbug_state lbug_query_result_get_arrow_schema(lbug_query_result* query_result,
+    struct ArrowSchema* out_schema);
+
+/**
+ * @brief Returns the next chunk of the query result as ArrowArray.
+ * @param query_result The query result instance to return.
+ * @param chunk_size The number of tuples to return in the chunk.
+ * @param[out] out_arrow_array The output parameter that will hold the arrow array representation of
+ * the query result. The arrow array internally stores an arrow struct with fields for each of the
+ * columns.
+ * @return The state indicating the success or failure of the operation.
+ *
+ * It is the caller's responsibility to call the release function to release the underlying data
+ */
+LBUG_C_API lbug_state lbug_query_result_get_next_arrow_chunk(lbug_query_result* query_result,
+    int64_t chunk_size, struct ArrowArray* out_arrow_array);
+
+// FlatTuple
+/**
+ * @brief Destroys the given flat tuple instance.
+ * @param flat_tuple The flat tuple instance to destroy.
+ */
+LBUG_C_API void lbug_flat_tuple_destroy(lbug_flat_tuple* flat_tuple);
+/**
+ * @brief Returns the value at index of the flat tuple.
+ * @param flat_tuple The flat tuple instance to return.
+ * @param index The index of the value to return.
+ * @param[out] out_value The output parameter that will hold the value at index.
+ * @return The state indicating the success or failure of the operation.
+ */
+LBUG_C_API lbug_state lbug_flat_tuple_get_value(lbug_flat_tuple* flat_tuple, uint64_t index,
+    lbug_value* out_value);
+/**
+ * @brief Converts the flat tuple to a string.
+ * @param flat_tuple The flat tuple instance to convert.
+ * @return The flat tuple as a string.
+ */
+LBUG_C_API char* lbug_flat_tuple_to_string(lbug_flat_tuple* flat_tuple);
+
+// DataType
+// TODO(Chang): Refactor the datatype constructor to follow the cpp way of creating dataTypes.
+/**
+ * @brief Creates a data type instance with the given id, childType and num_elements_in_array.
+ * Caller is responsible for destroying the returned data type instance.
+ * @param id The enum type id of the datatype to create.
+ * @param child_type The child type of the datatype to create(only used for nested dataTypes).
+ * @param num_elements_in_array The number of elements in the array(only used for ARRAY).
+ * @param[out] out_type The output parameter that will hold the data type instance.
+ * @return The state indicating the success or failure of the operation.
+ */
+LBUG_C_API void lbug_data_type_create(lbug_data_type_id id, lbug_logical_type* child_type,
+    uint64_t num_elements_in_array, lbug_logical_type* out_type);
+/**
+ * @brief Creates a new data type instance by cloning the given data type instance.
+ * @param data_type The data type instance to clone.
+ * @param[out] out_type The output parameter that will hold the cloned data type instance.
+ * @return The state indicating the success or failure of the operation.
+ */
+LBUG_C_API void lbug_data_type_clone(lbug_logical_type* data_type, lbug_logical_type* out_type);
+/**
+ * @brief Destroys the given data type instance.
+ * @param data_type The data type instance to destroy.
+ */
+LBUG_C_API void lbug_data_type_destroy(lbug_logical_type* data_type);
+/**
+ * @brief Returns true if the given data type is equal to the other data type, false otherwise.
+ * @param data_type1 The first data type instance to compare.
+ * @param data_type2 The second data type instance to compare.
+ */
+LBUG_C_API bool lbug_data_type_equals(lbug_logical_type* data_type1, lbug_logical_type* data_type2);
+/**
+ * @brief Returns the enum type id of the given data type.
+ * @param data_type The data type instance to return.
+ */
+LBUG_C_API lbug_data_type_id lbug_data_type_get_id(lbug_logical_type* data_type);
+/**
+ * @brief Returns the child type of the given ARRAY or LIST data type.
+ * @param data_type The ARRAY or LIST data type instance.
+ * @param[out] out_result The output parameter that will hold the child type.
+ * @return The state indicating the success or failure of the operation.
+ */
+LBUG_C_API lbug_state lbug_data_type_get_child_type(lbug_logical_type* data_type,
+    lbug_logical_type* out_result);
+/**
+ * @brief Returns the number of elements for array.
+ * @param data_type The data type instance to return.
+ * @param[out] out_result The output parameter that will hold the number of elements in the array.
+ * @return The state indicating the success or failure of the operation.
+ */
+LBUG_C_API lbug_state lbug_data_type_get_num_elements_in_array(lbug_logical_type* data_type,
+    uint64_t* out_result);
+
+// Value
+/**
+ * @brief Creates a NULL value of ANY type. Caller is responsible for destroying the returned value.
+ */
+LBUG_C_API lbug_value* lbug_value_create_null();
+/**
+ * @brief Creates a value of the given data type. Caller is responsible for destroying the
+ * returned value.
+ * @param data_type The data type of the value to create.
+ */
+LBUG_C_API lbug_value* lbug_value_create_null_with_data_type(lbug_logical_type* data_type);
+/**
+ * @brief Returns true if the given value is NULL, false otherwise.
+ * @param value The value instance to check.
+ */
+LBUG_C_API bool lbug_value_is_null(lbug_value* value);
+/**
+ * @brief Sets the given value to NULL or not.
+ * @param value The value instance to set.
+ * @param is_null True if sets the value to NULL, false otherwise.
+ */
+LBUG_C_API void lbug_value_set_null(lbug_value* value, bool is_null);
+/**
+ * @brief Creates a value of the given data type with default non-NULL value. Caller is responsible
+ * for destroying the returned value.
+ * @param data_type The data type of the value to create.
+ */
+LBUG_C_API lbug_value* lbug_value_create_default(lbug_logical_type* data_type);
+/**
+ * @brief Creates a value with boolean type and the given bool value. Caller is responsible for
+ * destroying the returned value.
+ * @param val_ The bool value of the value to create.
+ */
+LBUG_C_API lbug_value* lbug_value_create_bool(bool val_);
+/**
+ * @brief Creates a value with int8 type and the given int8 value. Caller is responsible for
+ * destroying the returned value.
+ * @param val_ The int8 value of the value to create.
+ */
+LBUG_C_API lbug_value* lbug_value_create_int8(int8_t val_);
+/**
+ * @brief Creates a value with int16 type and the given int16 value. Caller is responsible for
+ * destroying the returned value.
+ * @param val_ The int16 value of the value to create.
+ */
+LBUG_C_API lbug_value* lbug_value_create_int16(int16_t val_);
+/**
+ * @brief Creates a value with int32 type and the given int32 value. Caller is responsible for
+ * destroying the returned value.
+ * @param val_ The int32 value of the value to create.
+ */
+LBUG_C_API lbug_value* lbug_value_create_int32(int32_t val_);
+/**
+ * @brief Creates a value with int64 type and the given int64 value. Caller is responsible for
+ * destroying the returned value.
+ * @param val_ The int64 value of the value to create.
+ */
+LBUG_C_API lbug_value* lbug_value_create_int64(int64_t val_);
+/**
+ * @brief Creates a value with uint8 type and the given uint8 value. Caller is responsible for
+ * destroying the returned value.
+ * @param val_ The uint8 value of the value to create.
+ */
+LBUG_C_API lbug_value* lbug_value_create_uint8(uint8_t val_);
+/**
+ * @brief Creates a value with uint16 type and the given uint16 value. Caller is responsible for
+ * destroying the returned value.
+ * @param val_ The uint16 value of the value to create.
+ */
+LBUG_C_API lbug_value* lbug_value_create_uint16(uint16_t val_);
+/**
+ * @brief Creates a value with uint32 type and the given uint32 value. Caller is responsible for
+ * destroying the returned value.
+ * @param val_ The uint32 value of the value to create.
+ */
+LBUG_C_API lbug_value* lbug_value_create_uint32(uint32_t val_);
+/**
+ * @brief Creates a value with uint64 type and the given uint64 value. Caller is responsible for
+ * destroying the returned value.
+ * @param val_ The uint64 value of the value to create.
+ */
+LBUG_C_API lbug_value* lbug_value_create_uint64(uint64_t val_);
+/**
+ * @brief Creates a value with int128 type and the given int128 value. Caller is responsible for
+ * destroying the returned value.
+ * @param val_ The int128 value of the value to create.
+ */
+LBUG_C_API lbug_value* lbug_value_create_int128(lbug_int128_t val_);
+/**
+ * @brief Creates a value with float type and the given float value. Caller is responsible for
+ * destroying the returned value.
+ * @param val_ The float value of the value to create.
+ */
+LBUG_C_API lbug_value* lbug_value_create_float(float val_);
+/**
+ * @brief Creates a value with double type and the given double value. Caller is responsible for
+ * destroying the returned value.
+ * @param val_ The double value of the value to create.
+ */
+LBUG_C_API lbug_value* lbug_value_create_double(double val_);
+/**
+ * @brief Creates a value with decimal type and the given string representation.
+ * Caller is responsible for destroying the returned value.
+ * @param val_ The decimal value to create.
+ * @param precision The decimal precision.
+ * @param scale The decimal scale.
+ */
+LBUG_C_API lbug_value* lbug_value_create_decimal(const char* val_, uint32_t precision,
+    uint32_t scale);
+/**
+ * @brief Creates a value with internal_id type and the given internal_id value. Caller is
+ * responsible for destroying the returned value.
+ * @param val_ The internal_id value of the value to create.
+ */
+LBUG_C_API lbug_value* lbug_value_create_internal_id(lbug_internal_id_t val_);
+/**
+ * @brief Creates a value with date type and the given date value. Caller is responsible for
+ * destroying the returned value.
+ * @param val_ The date value of the value to create.
+ */
+LBUG_C_API lbug_value* lbug_value_create_date(lbug_date_t val_);
+/**
+ * @brief Creates a value with timestamp_ns type and the given timestamp value. Caller is
+ * responsible for destroying the returned value.
+ * @param val_ The timestamp_ns value of the value to create.
+ */
+LBUG_C_API lbug_value* lbug_value_create_timestamp_ns(lbug_timestamp_ns_t val_);
+/**
+ * @brief Creates a value with timestamp_ms type and the given timestamp value. Caller is
+ * responsible for destroying the returned value.
+ * @param val_ The timestamp_ms value of the value to create.
+ */
+LBUG_C_API lbug_value* lbug_value_create_timestamp_ms(lbug_timestamp_ms_t val_);
+/**
+ * @brief Creates a value with timestamp_sec type and the given timestamp value. Caller is
+ * responsible for destroying the returned value.
+ * @param val_ The timestamp_sec value of the value to create.
+ */
+LBUG_C_API lbug_value* lbug_value_create_timestamp_sec(lbug_timestamp_sec_t val_);
+/**
+ * @brief Creates a value with timestamp_tz type and the given timestamp value. Caller is
+ * responsible for destroying the returned value.
+ * @param val_ The timestamp_tz value of the value to create.
+ */
+LBUG_C_API lbug_value* lbug_value_create_timestamp_tz(lbug_timestamp_tz_t val_);
+/**
+ * @brief Creates a value with timestamp type and the given timestamp value. Caller is responsible
+ * for destroying the returned value.
+ * @param val_ The timestamp value of the value to create.
+ */
+LBUG_C_API lbug_value* lbug_value_create_timestamp(lbug_timestamp_t val_);
+/**
+ * @brief Creates a value with interval type and the given interval value. Caller is responsible
+ * for destroying the returned value.
+ * @param val_ The interval value of the value to create.
+ */
+LBUG_C_API lbug_value* lbug_value_create_interval(lbug_interval_t val_);
+/**
+ * @brief Creates a value with string type and the given string value. Caller is responsible for
+ * destroying the returned value.
+ * @param val_ The string value of the value to create.
+ */
+LBUG_C_API lbug_value* lbug_value_create_string(const char* val_);
+/**
+ * @brief Creates a value with JSON type and the given JSON string representation.
+ * Caller is responsible for destroying the returned value.
+ * @param val_ The JSON string value to create.
+ */
+LBUG_C_API lbug_value* lbug_value_create_json(const char* val_);
+/**
+ * @brief Creates a value with UUID type and the given string representation.
+ * Caller is responsible for destroying the returned value.
+ * @param val_ The UUID string value to create.
+ */
+LBUG_C_API lbug_value* lbug_value_create_uuid(const char* val_);
+/**
+ * @brief Creates a list value with the given number of elements and the given elements.
+ * The caller needs to make sure that all elements have the same type.
+ * The elements are copied into the list value, so destroying the elements after creating the list
+ * value is safe.
+ * Caller is responsible for destroying the returned value.
+ * @param num_elements The number of elements in the list.
+ * @param elements The elements of the list.
+ * @param[out] out_value The output parameter that will hold a pointer to the created list value.
+ * @return The state indicating the success or failure of the operation.
+ */
+LBUG_C_API lbug_state lbug_value_create_list(uint64_t num_elements, lbug_value** elements,
+    lbug_value** out_value);
+/**
+ * @brief Creates a struct value with the given number of fields and the given field names and
+ * values. The caller needs to make sure that all field names are unique.
+ * The field names and values are copied into the struct value, so destroying the field names and
+ * values after creating the struct value is safe.
+ * Caller is responsible for destroying the returned value.
+ * @param num_fields The number of fields in the struct.
+ * @param field_names The field names of the struct.
+ * @param field_values The field values of the struct.
+ * @param[out] out_value The output parameter that will hold a pointer to the created struct value.
+ * @return The state indicating the success or failure of the operation.
+ */
+LBUG_C_API lbug_state lbug_value_create_struct(uint64_t num_fields, const char** field_names,
+    lbug_value** field_values, lbug_value** out_value);
+/**
+ * @brief Creates a map value with the given number of fields and the given keys and values. The
+ * caller needs to make sure that all keys are unique, and all keys and values have the same type.
+ * The keys and values are copied into the map value, so destroying the keys and values after
+ * creating the map value is safe.
+ * Caller is responsible for destroying the returned value.
+ * @param num_fields The number of fields in the map.
+ * @param keys The keys of the map.
+ * @param values The values of the map.
+ * @param[out] out_value The output parameter that will hold a pointer to the created map value.
+ * @return The state indicating the success or failure of the operation.
+ */
+LBUG_C_API lbug_state lbug_value_create_map(uint64_t num_fields, lbug_value** keys,
+    lbug_value** values, lbug_value** out_value);
+/**
+ * @brief Creates a new value based on the given value. Caller is responsible for destroying the
+ * returned value.
+ * @param value The value to create from.
+ */
+LBUG_C_API lbug_value* lbug_value_clone(lbug_value* value);
+/**
+ * @brief Copies the other value to the value.
+ * @param value The value to copy to.
+ * @param other The value to copy from.
+ */
+LBUG_C_API void lbug_value_copy(lbug_value* value, lbug_value* other);
+/**
+ * @brief Destroys the value.
+ * @param value The value to destroy.
+ */
+LBUG_C_API void lbug_value_destroy(lbug_value* value);
+/**
+ * @brief Returns the number of elements per list of the given value. The value must be of type
+ * ARRAY.
+ * @param value The ARRAY value to get list size.
+ * @param[out] out_result The output parameter that will hold the number of elements per list.
+ * @return The state indicating the success or failure of the operation.
+ */
+LBUG_C_API lbug_state lbug_value_get_list_size(lbug_value* value, uint64_t* out_result);
+/**
+ * @brief Returns the element at index of the given value. The value must be of type LIST.
+ * @param value The LIST value to return.
+ * @param index The index of the element to return.
+ * @param[out] out_value The output parameter that will hold the element at index.
+ * @return The state indicating the success or failure of the operation.
+ */
+LBUG_C_API lbug_state lbug_value_get_list_element(lbug_value* value, uint64_t index,
+    lbug_value* out_value);
+/**
+ * @brief Returns the number of fields of the given struct value. The value must be of type STRUCT.
+ * @param value The STRUCT value to get number of fields.
+ * @param[out] out_result The output parameter that will hold the number of fields.
+ * @return The state indicating the success or failure of the operation.
+ */
+LBUG_C_API lbug_state lbug_value_get_struct_num_fields(lbug_value* value, uint64_t* out_result);
+/**
+ * @brief Returns the field name at index of the given struct value. The value must be of physical
+ * type STRUCT (STRUCT, NODE, REL, RECURSIVE_REL, UNION).
+ * @param value The STRUCT value to get field name.
+ * @param index The index of the field name to return.
+ * @param[out] out_result The output parameter that will hold the field name at index.
+ * @return The state indicating the success or failure of the operation.
+ */
+LBUG_C_API lbug_state lbug_value_get_struct_field_name(lbug_value* value, uint64_t index,
+    char** out_result);
+/**
+ * @brief Returns the field index for the given field name in the given struct value.
+ * @param value The STRUCT value to inspect.
+ * @param field_name The field name to look up.
+ * @param[out] out_result The output parameter that will hold the field index.
+ * @return The state indicating the success or failure of the operation.
+ */
+LBUG_C_API lbug_state lbug_value_get_struct_field_index(lbug_value* value, const char* field_name,
+    uint64_t* out_result);
+/**
+ * @brief Returns the field value at index of the given struct value. The value must be of physical
+ * type STRUCT (STRUCT, NODE, REL, RECURSIVE_REL, UNION).
+ * @param value The STRUCT value to get field value.
+ * @param index The index of the field value to return.
+ * @param[out] out_value The output parameter that will hold the field value at index.
+ * @return The state indicating the success or failure of the operation.
+ */
+LBUG_C_API lbug_state lbug_value_get_struct_field_value(lbug_value* value, uint64_t index,
+    lbug_value* out_value);
+
+/**
+ * @brief Returns the size of the given map value. The value must be of type MAP.
+ * @param value The MAP value to get size.
+ * @param[out] out_result The output parameter that will hold the size of the map.
+ * @return The state indicating the success or failure of the operation.
+ */
+LBUG_C_API lbug_state lbug_value_get_map_size(lbug_value* value, uint64_t* out_result);
+/**
+ * @brief Returns the key at index of the given map value. The value must be of physical
+ * type MAP.
+ * @param value The MAP value to get key.
+ * @param index The index of the field name to return.
+ * @param[out] out_key The output parameter that will hold the key at index.
+ * @return The state indicating the success or failure of the operation.
+ */
+LBUG_C_API lbug_state lbug_value_get_map_key(lbug_value* value, uint64_t index,
+    lbug_value* out_key);
+/**
+ * @brief Returns the field value at index of the given map value. The value must be of physical
+ * type MAP.
+ * @param value The MAP value to get field value.
+ * @param index The index of the field value to return.
+ * @param[out] out_value The output parameter that will hold the field value at index.
+ * @return The state indicating the success or failure of the operation.
+ */
+LBUG_C_API lbug_state lbug_value_get_map_value(lbug_value* value, uint64_t index,
+    lbug_value* out_value);
+/**
+ * @brief Returns the list of nodes for recursive rel value. The value must be of type
+ * RECURSIVE_REL.
+ * @param value The RECURSIVE_REL value to return.
+ * @param[out] out_value The output parameter that will hold the list of nodes.
+ * @return The state indicating the success or failure of the operation.
+ */
+LBUG_C_API lbug_state lbug_value_get_recursive_rel_node_list(lbug_value* value,
+    lbug_value* out_value);
+
+/**
+ * @brief Returns the list of rels for recursive rel value. The value must be of type RECURSIVE_REL.
+ * @param value The RECURSIVE_REL value to return.
+ * @param[out] out_value The output parameter that will hold the list of rels.
+ * @return The state indicating the success or failure of the operation.
+ */
+LBUG_C_API lbug_state lbug_value_get_recursive_rel_rel_list(lbug_value* value,
+    lbug_value* out_value);
+/**
+ * @brief Returns internal type of the given value.
+ * @param value The value to return.
+ * @param[out] out_type The output parameter that will hold the internal type of the value.
+ */
+LBUG_C_API void lbug_value_get_data_type(lbug_value* value, lbug_logical_type* out_type);
+/**
+ * @brief Returns the boolean value of the given value. The value must be of type BOOL.
+ * @param value The value to return.
+ * @param[out] out_result The output parameter that will hold the boolean value.
+ * @return The state indicating the success or failure of the operation.
+ */
+LBUG_C_API lbug_state lbug_value_get_bool(lbug_value* value, bool* out_result);
+/**
+ * @brief Returns the int8 value of the given value. The value must be of type INT8.
+ * @param value The value to return.
+ * @param[out] out_result The output parameter that will hold the int8 value.
+ * @return The state indicating the success or failure of the operation.
+ */
+LBUG_C_API lbug_state lbug_value_get_int8(lbug_value* value, int8_t* out_result);
+/**
+ * @brief Returns the int16 value of the given value. The value must be of type INT16.
+ * @param value The value to return.
+ * @param[out] out_result The output parameter that will hold the int16 value.
+ * @return The state indicating the success or failure of the operation.
+ */
+LBUG_C_API lbug_state lbug_value_get_int16(lbug_value* value, int16_t* out_result);
+/**
+ * @brief Returns the int32 value of the given value. The value must be of type INT32.
+ * @param value The value to return.
+ * @param[out] out_result The output parameter that will hold the int32 value.
+ * @return The state indicating the success or failure of the operation.
+ */
+LBUG_C_API lbug_state lbug_value_get_int32(lbug_value* value, int32_t* out_result);
+/**
+ * @brief Returns the int64 value of the given value. The value must be of type INT64 or SERIAL.
+ * @param value The value to return.
+ * @param[out] out_result The output parameter that will hold the int64 value.
+ * @return The state indicating the success or failure of the operation.
+ */
+LBUG_C_API lbug_state lbug_value_get_int64(lbug_value* value, int64_t* out_result);
+/**
+ * @brief Returns the uint8 value of the given value. The value must be of type UINT8.
+ * @param value The value to return.
+ * @param[out] out_result The output parameter that will hold the uint8 value.
+ * @return The state indicating the success or failure of the operation.
+ */
+LBUG_C_API lbug_state lbug_value_get_uint8(lbug_value* value, uint8_t* out_result);
+/**
+ * @brief Returns the uint16 value of the given value. The value must be of type UINT16.
+ * @param value The value to return.
+ * @param[out] out_result The output parameter that will hold the uint16 value.
+ * @return The state indicating the success or failure of the operation.
+ */
+LBUG_C_API lbug_state lbug_value_get_uint16(lbug_value* value, uint16_t* out_result);
+/**
+ * @brief Returns the uint32 value of the given value. The value must be of type UINT32.
+ * @param value The value to return.
+ * @param[out] out_result The output parameter that will hold the uint32 value.
+ * @return The state indicating the success or failure of the operation.
+ */
+LBUG_C_API lbug_state lbug_value_get_uint32(lbug_value* value, uint32_t* out_result);
+/**
+ * @brief Returns the uint64 value of the given value. The value must be of type UINT64.
+ * @param value The value to return.
+ * @param[out] out_result The output parameter that will hold the uint64 value.
+ * @return The state indicating the success or failure of the operation.
+ */
+LBUG_C_API lbug_state lbug_value_get_uint64(lbug_value* value, uint64_t* out_result);
+/**
+ * @brief Returns the int128 value of the given value. The value must be of type INT128.
+ * @param value The value to return.
+ * @param[out] out_result The output parameter that will hold the int128 value.
+ * @return The state indicating the success or failure of the operation.
+ */
+LBUG_C_API lbug_state lbug_value_get_int128(lbug_value* value, lbug_int128_t* out_result);
+/**
+ * @brief convert a string to int128 value.
+ * @param str The string to convert.
+ * @param[out] out_result The output parameter that will hold the int128 value.
+ * @return The state indicating the success or failure of the operation.
+ */
+LBUG_C_API lbug_state lbug_int128_t_from_string(const char* str, lbug_int128_t* out_result);
+/**
+ * @brief convert int128 to corresponding string.
+ * @param val The int128 value to convert.
+ * @param[out] out_result The output parameter that will hold the string value.
+ * @return The state indicating the success or failure of the operation.
+ */
+LBUG_C_API lbug_state lbug_int128_t_to_string(lbug_int128_t val, char** out_result);
+/**
+ * @brief Returns the float value of the given value. The value must be of type FLOAT.
+ * @param value The value to return.
+ * @param[out] out_result The output parameter that will hold the float value.
+ * @return The state indicating the success or failure of the operation.
+ */
+LBUG_C_API lbug_state lbug_value_get_float(lbug_value* value, float* out_result);
+/**
+ * @brief Returns the double value of the given value. The value must be of type DOUBLE.
+ * @param value The value to return.
+ * @param[out] out_result The output parameter that will hold the double value.
+ * @return The state indicating the success or failure of the operation.
+ */
+LBUG_C_API lbug_state lbug_value_get_double(lbug_value* value, double* out_result);
+/**
+ * @brief Returns the internal id value of the given value. The value must be of type INTERNAL_ID.
+ * @param value The value to return.
+ * @param[out] out_result The output parameter that will hold the internal id value.
+ * @return The state indicating the success or failure of the operation.
+ */
+LBUG_C_API lbug_state lbug_value_get_internal_id(lbug_value* value, lbug_internal_id_t* out_result);
+/**
+ * @brief Returns the date value of the given value. The value must be of type DATE.
+ * @param value The value to return.
+ * @param[out] out_result The output parameter that will hold the date value.
+ * @return The state indicating the success or failure of the operation.
+ */
+LBUG_C_API lbug_state lbug_value_get_date(lbug_value* value, lbug_date_t* out_result);
+/**
+ * @brief Returns the timestamp value of the given value. The value must be of type TIMESTAMP.
+ * @param value The value to return.
+ * @param[out] out_result The output parameter that will hold the timestamp value.
+ * @return The state indicating the success or failure of the operation.
+ */
+LBUG_C_API lbug_state lbug_value_get_timestamp(lbug_value* value, lbug_timestamp_t* out_result);
+/**
+ * @brief Returns the timestamp_ns value of the given value. The value must be of type TIMESTAMP_NS.
+ * @param value The value to return.
+ * @param[out] out_result The output parameter that will hold the timestamp_ns value.
+ * @return The state indicating the success or failure of the operation.
+ */
+LBUG_C_API lbug_state lbug_value_get_timestamp_ns(lbug_value* value,
+    lbug_timestamp_ns_t* out_result);
+/**
+ * @brief Returns the timestamp_ms value of the given value. The value must be of type TIMESTAMP_MS.
+ * @param value The value to return.
+ * @param[out] out_result The output parameter that will hold the timestamp_ms value.
+ * @return The state indicating the success or failure of the operation.
+ */
+LBUG_C_API lbug_state lbug_value_get_timestamp_ms(lbug_value* value,
+    lbug_timestamp_ms_t* out_result);
+/**
+ * @brief Returns the timestamp_sec value of the given value. The value must be of type
+ * TIMESTAMP_SEC.
+ * @param value The value to return.
+ * @param[out] out_result The output parameter that will hold the timestamp_sec value.
+ * @return The state indicating the success or failure of the operation.
+ */
+LBUG_C_API lbug_state lbug_value_get_timestamp_sec(lbug_value* value,
+    lbug_timestamp_sec_t* out_result);
+/**
+ * @brief Returns the timestamp_tz value of the given value. The value must be of type TIMESTAMP_TZ.
+ * @param value The value to return.
+ * @param[out] out_result The output parameter that will hold the timestamp_tz value.
+ * @return The state indicating the success or failure of the operation.
+ */
+LBUG_C_API lbug_state lbug_value_get_timestamp_tz(lbug_value* value,
+    lbug_timestamp_tz_t* out_result);
+/**
+ * @brief Returns the interval value of the given value. The value must be of type INTERVAL.
+ * @param value The value to return.
+ * @param[out] out_result The output parameter that will hold the interval value.
+ * @return The state indicating the success or failure of the operation.
+ */
+LBUG_C_API lbug_state lbug_value_get_interval(lbug_value* value, lbug_interval_t* out_result);
+/**
+ * @brief Returns the decimal value of the given value as a string. The value must be of type
+ * DECIMAL.
+ * @param value The value to return.
+ * @param[out] out_result The output parameter that will hold the decimal value.
+ * @return The state indicating the success or failure of the operation.
+ */
+LBUG_C_API lbug_state lbug_value_get_decimal_as_string(lbug_value* value, char** out_result);
+/**
+ * @brief Returns the string value of the given value. The value must be of type STRING.
+ * @param value The value to return.
+ * @param[out] out_result The output parameter that will hold the string value.
+ * @return The state indicating the success or failure of the operation.
+ */
+LBUG_C_API lbug_state lbug_value_get_string(lbug_value* value, char** out_result);
+/**
+ * @brief Returns the blob value of the given value. The value must be of type BLOB.
+ * @param value The value to return.
+ * @param[out] out_result The output parameter that will hold the blob value.
+ * @param[out] out_length The output parameter that will hold the length of the blob.
+ * @return The state indicating the success or failure of the operation.
+ * @note The caller is responsible for freeing the returned memory using `lbug_destroy_blob`.
+ */
+LBUG_C_API lbug_state lbug_value_get_blob(lbug_value* value, uint8_t** out_result,
+    uint64_t* out_length);
+/**
+ * @brief Returns the uuid value of the given value.
+ * to a string. The value must be of type UUID.
+ * @param value The value to return.
+ * @param[out] out_result The output parameter that will hold the uuid value.
+ * @return The state indicating the success or failure of the operation.
+ */
+LBUG_C_API lbug_state lbug_value_get_uuid(lbug_value* value, char** out_result);
+/**
+ * @brief Converts the given value to string.
+ * @param value The value to convert.
+ * @return The value as a string.
+ */
+LBUG_C_API char* lbug_value_to_string(lbug_value* value);
+/**
+ * @brief Returns the internal id value of the given node value as a lbug value.
+ * @param node_val The node value to return.
+ * @param[out] out_value The output parameter that will hold the internal id value.
+ * @return The state indicating the success or failure of the operation.
+ */
+LBUG_C_API lbug_state lbug_node_val_get_id_val(lbug_value* node_val, lbug_value* out_value);
+/**
+ * @brief Returns the label value of the given node value as a label value.
+ * @param node_val The node value to return.
+ * @param[out] out_value The output parameter that will hold the label value.
+ * @return The state indicating the success or failure of the operation.
+ */
+LBUG_C_API lbug_state lbug_node_val_get_label_val(lbug_value* node_val, lbug_value* out_value);
+/**
+ * @brief Returns the number of properties of the given node value.
+ * @param node_val The node value to return.
+ * @param[out] out_value The output parameter that will hold the number of properties.
+ * @return The state indicating the success or failure of the operation.
+ */
+LBUG_C_API lbug_state lbug_node_val_get_property_size(lbug_value* node_val, uint64_t* out_value);
+/**
+ * @brief Returns the property name of the given node value at the given index.
+ * @param node_val The node value to return.
+ * @param index The index of the property.
+ * @param[out] out_result The output parameter that will hold the property name at index.
+ * @return The state indicating the success or failure of the operation.
+ */
+LBUG_C_API lbug_state lbug_node_val_get_property_name_at(lbug_value* node_val, uint64_t index,
+    char** out_result);
+/**
+ * @brief Returns the property value of the given node value at the given index.
+ * @param node_val The node value to return.
+ * @param index The index of the property.
+ * @param[out] out_value The output parameter that will hold the property value at index.
+ * @return The state indicating the success or failure of the operation.
+ */
+LBUG_C_API lbug_state lbug_node_val_get_property_value_at(lbug_value* node_val, uint64_t index,
+    lbug_value* out_value);
+/**
+ * @brief Converts the given node value to string.
+ * @param node_val The node value to convert.
+ * @param[out] out_result The output parameter that will hold the node value as a string.
+ * @return The state indicating the success or failure of the operation.
+ */
+LBUG_C_API lbug_state lbug_node_val_to_string(lbug_value* node_val, char** out_result);
+/**
+ * @brief Returns the internal id value of the rel value as a lbug value.
+ * @param rel_val The rel value to return.
+ * @param[out] out_value The output parameter that will hold the internal id value.
+ * @return The state indicating the success or failure of the operation.
+ */
+LBUG_C_API lbug_state lbug_rel_val_get_id_val(lbug_value* rel_val, lbug_value* out_value);
+/**
+ * @brief Returns the internal id value of the source node of the given rel value as a lbug value.
+ * @param rel_val The rel value to return.
+ * @param[out] out_value The output parameter that will hold the internal id value.
+ * @return The state indicating the success or failure of the operation.
+ */
+LBUG_C_API lbug_state lbug_rel_val_get_src_id_val(lbug_value* rel_val, lbug_value* out_value);
+/**
+ * @brief Returns the internal id value of the destination node of the given rel value as a lbug
+ * value.
+ * @param rel_val The rel value to return.
+ * @param[out] out_value The output parameter that will hold the internal id value.
+ * @return The state indicating the success or failure of the operation.
+ */
+LBUG_C_API lbug_state lbug_rel_val_get_dst_id_val(lbug_value* rel_val, lbug_value* out_value);
+/**
+ * @brief Returns the label value of the given rel value.
+ * @param rel_val The rel value to return.
+ * @param[out] out_value The output parameter that will hold the label value.
+ * @return The state indicating the success or failure of the operation.
+ */
+LBUG_C_API lbug_state lbug_rel_val_get_label_val(lbug_value* rel_val, lbug_value* out_value);
+/**
+ * @brief Returns the number of properties of the given rel value.
+ * @param rel_val The rel value to return.
+ * @param[out] out_value The output parameter that will hold the number of properties.
+ * @return The state indicating the success or failure of the operation.
+ */
+LBUG_C_API lbug_state lbug_rel_val_get_property_size(lbug_value* rel_val, uint64_t* out_value);
+/**
+ * @brief Returns the property name of the given rel value at the given index.
+ * @param rel_val The rel value to return.
+ * @param index The index of the property.
+ * @param[out] out_result The output parameter that will hold the property name at index.
+ * @return The state indicating the success or failure of the operation.
+ */
+LBUG_C_API lbug_state lbug_rel_val_get_property_name_at(lbug_value* rel_val, uint64_t index,
+    char** out_result);
+/**
+ * @brief Returns the property of the given rel value at the given index as lbug value.
+ * @param rel_val The rel value to return.
+ * @param index The index of the property.
+ * @param[out] out_value The output parameter that will hold the property value at index.
+ * @return The state indicating the success or failure of the operation.
+ */
+LBUG_C_API lbug_state lbug_rel_val_get_property_value_at(lbug_value* rel_val, uint64_t index,
+    lbug_value* out_value);
+/**
+ * @brief Converts the given rel value to string.
+ * @param rel_val The rel value to convert.
+ * @param[out] out_result The output parameter that will hold the rel value as a string.
+ * @return The state indicating the success or failure of the operation.
+ */
+LBUG_C_API lbug_state lbug_rel_val_to_string(lbug_value* rel_val, char** out_result);
+/**
+ * @brief Destroys any string created by the Lbug C API, including both the error message and the
+ * values returned by the API functions. This function is provided to avoid the inconsistency
+ * between the memory allocation and deallocation across different libraries and is preferred over
+ * using the standard C free function.
+ * @param str The string to destroy.
+ */
+LBUG_C_API void lbug_destroy_string(char* str);
+/**
+ * @brief Destroys any blob created by the Lbug C API. This function is provided to avoid the
+ * inconsistency between the memory allocation and deallocation across different libraries and
+ * is preferred over using the standard C free function.
+ * @param blob The blob to destroy.
+ */
+LBUG_C_API void lbug_destroy_blob(uint8_t* blob);
+
+// QuerySummary
+/**
+ * @brief Destroys the given query summary.
+ * @param query_summary The query summary to destroy.
+ */
+LBUG_C_API void lbug_query_summary_destroy(lbug_query_summary* query_summary);
+/**
+ * @brief Returns the compilation time of the given query summary in milliseconds.
+ * @param query_summary The query summary to get compilation time.
+ */
+LBUG_C_API double lbug_query_summary_get_compiling_time(lbug_query_summary* query_summary);
+/**
+ * @brief Returns the execution time of the given query summary in milliseconds.
+ * @param query_summary The query summary to get execution time.
+ */
+LBUG_C_API double lbug_query_summary_get_execution_time(lbug_query_summary* query_summary);
+
+// Utility functions
+/**
+ * @brief Convert timestamp_ns to corresponding tm struct.
+ * @param timestamp The timestamp_ns value to convert.
+ * @param[out] out_result The output parameter that will hold the tm struct.
+ * @return The state indicating the success or failure of the operation.
+ */
+LBUG_C_API lbug_state lbug_timestamp_ns_to_tm(lbug_timestamp_ns_t timestamp, struct tm* out_result);
+/**
+ * @brief Convert timestamp_ms to corresponding tm struct.
+ * @param timestamp The timestamp_ms value to convert.
+ * @param[out] out_result The output parameter that will hold the tm struct.
+ * @return The state indicating the success or failure of the operation.
+ */
+LBUG_C_API lbug_state lbug_timestamp_ms_to_tm(lbug_timestamp_ms_t timestamp, struct tm* out_result);
+/**
+ * @brief Convert timestamp_sec to corresponding tm struct.
+ * @param timestamp The timestamp_sec value to convert.
+ * @param[out] out_result The output parameter that will hold the tm struct.
+ * @return The state indicating the success or failure of the operation.
+ */
+LBUG_C_API lbug_state lbug_timestamp_sec_to_tm(lbug_timestamp_sec_t timestamp,
+    struct tm* out_result);
+/**
+ * @brief Convert timestamp_tz to corresponding tm struct.
+ * @param timestamp The timestamp_tz value to convert.
+ * @param[out] out_result The output parameter that will hold the tm struct.
+ * @return The state indicating the success or failure of the operation.
+ */
+LBUG_C_API lbug_state lbug_timestamp_tz_to_tm(lbug_timestamp_tz_t timestamp, struct tm* out_result);
+/**
+ * @brief Convert timestamp to corresponding tm struct.
+ * @param timestamp The timestamp value to convert.
+ * @param[out] out_result The output parameter that will hold the tm struct.
+ * @return The state indicating the success or failure of the operation.
+ */
+LBUG_C_API lbug_state lbug_timestamp_to_tm(lbug_timestamp_t timestamp, struct tm* out_result);
+/**
+ * @brief Convert tm struct to timestamp_ns value.
+ * @param tm The tm struct to convert.
+ * @param[out] out_result The output parameter that will hold the timestamp_ns value.
+ * @return The state indicating the success or failure of the operation.
+ */
+LBUG_C_API lbug_state lbug_timestamp_ns_from_tm(struct tm tm, lbug_timestamp_ns_t* out_result);
+/**
+ * @brief Convert tm struct to timestamp_ms value.
+ * @param tm The tm struct to convert.
+ * @param[out] out_result The output parameter that will hold the timestamp_ms value.
+ * @return The state indicating the success or failure of the operation.
+ */
+LBUG_C_API lbug_state lbug_timestamp_ms_from_tm(struct tm tm, lbug_timestamp_ms_t* out_result);
+/**
+ * @brief Convert tm struct to timestamp_sec value.
+ * @param tm The tm struct to convert.
+ * @param[out] out_result The output parameter that will hold the timestamp_sec value.
+ * @return The state indicating the success or failure of the operation.
+ */
+LBUG_C_API lbug_state lbug_timestamp_sec_from_tm(struct tm tm, lbug_timestamp_sec_t* out_result);
+/**
+ * @brief Convert tm struct to timestamp_tz value.
+ * @param tm The tm struct to convert.
+ * @param[out] out_result The output parameter that will hold the timestamp_tz value.
+ * @return The state indicating the success or failure of the operation.
+ */
+LBUG_C_API lbug_state lbug_timestamp_tz_from_tm(struct tm tm, lbug_timestamp_tz_t* out_result);
+/**
+ * @brief Convert timestamp_ns to corresponding string.
+ * @param timestamp The timestamp_ns value to convert.
+ * @param[out] out_result The output parameter that will hold the string value.
+ * @return The state indicating the success or failure of the operation.
+ */
+LBUG_C_API lbug_state lbug_timestamp_from_tm(struct tm tm, lbug_timestamp_t* out_result);
+/**
+ * @brief Convert date to corresponding string.
+ * @param date The date value to convert.
+ * @param[out] out_result The output parameter that will hold the string value.
+ * @return The state indicating the success or failure of the operation.
+ */
+LBUG_C_API lbug_state lbug_date_to_string(lbug_date_t date, char** out_result);
+/**
+ * @brief Convert a string to date value.
+ * @param str The string to convert.
+ * @param[out] out_result The output parameter that will hold the date value.
+ * @return The state indicating the success or failure of the operation.
+ */
+LBUG_C_API lbug_state lbug_date_from_string(const char* str, lbug_date_t* out_result);
+/**
+ * @brief Convert date to corresponding tm struct.
+ * @param date The date value to convert.
+ * @param[out] out_result The output parameter that will hold the tm struct.
+ * @return The state indicating the success or failure of the operation.
+ */
+LBUG_C_API lbug_state lbug_date_to_tm(lbug_date_t date, struct tm* out_result);
+/**
+ * @brief Convert tm struct to date value.
+ * @param tm The tm struct to convert.
+ * @param[out] out_result The output parameter that will hold the date value.
+ * @return The state indicating the success or failure of the operation.
+ */
+LBUG_C_API lbug_state lbug_date_from_tm(struct tm tm, lbug_date_t* out_result);
+/**
+ * @brief Convert interval to corresponding difftime value in seconds.
+ * @param interval The interval value to convert.
+ * @param[out] out_result The output parameter that will hold the difftime value.
+ */
+LBUG_C_API void lbug_interval_to_difftime(lbug_interval_t interval, double* out_result);
+/**
+ * @brief Convert difftime value in seconds to interval.
+ * @param difftime The difftime value to convert.
+ * @param[out] out_result The output parameter that will hold the interval value.
+ */
+LBUG_C_API void lbug_interval_from_difftime(double difftime, lbug_interval_t* out_result);
+
+// Version
+/**
+ * @brief Returns the version of the Lbug library.
+ */
+LBUG_C_API char* lbug_get_version();
+
+/**
+ * @brief Returns the storage version of the Lbug library.
+ */
+LBUG_C_API uint64_t lbug_get_storage_version();
+
+// Error handling
+/**
+ * @brief Returns the last error message set by the C API, consuming it (subsequent calls return
+ * nullptr until another error occurs). The caller is responsible for freeing the returned string
+ * using lbug_destroy_string(). Returns nullptr if no error has been recorded.
+ */
+LBUG_C_API char* lbug_get_last_error();
+#undef LBUG_C_API

--- a/ingestion_factstore.go
+++ b/ingestion_factstore.go
@@ -11,6 +11,7 @@ import (
 	"github.com/soundprediction/predicato/pkg/modeler"
 	"github.com/soundprediction/predicato/pkg/nlp"
 	"github.com/soundprediction/predicato/pkg/prompts"
+	"github.com/soundprediction/predicato/pkg/ruleschema"
 	"github.com/soundprediction/predicato/pkg/types"
 	"github.com/soundprediction/predicato/pkg/utils"
 	"github.com/soundprediction/predicato/pkg/utils/maintenance"
@@ -334,8 +335,16 @@ func (c *Client) ExtractToFacts(ctx context.Context, episode types.Episode, opti
 
 				// Convert nlp.Rule → types.ExtractedRule
 				for _, r := range result.Rules {
+					ruleID := fmt.Sprintf("%s-rule-%d-%d", episode.ID, chunkIdx, len(knowledgeRules))
+					nlp.CompileRuleStructure(&r, nlp.RuleStructureMetadata{
+						ID:            ruleID,
+						SourceID:      episode.ID,
+						Model:         extModel,
+						ChunkIndex:    chunkIdx,
+						HasChunkIndex: true,
+					})
 					knowledgeRules = append(knowledgeRules, &types.ExtractedRule{
-						ID:                fmt.Sprintf("%s-rule-%d-%d", episode.ID, chunkIdx, len(knowledgeRules)),
+						ID:                ruleID,
 						SourceID:          episode.ID,
 						Antecedent:        r.Antecedent,
 						Consequent:        r.Consequent,
@@ -347,6 +356,9 @@ func (c *Client) ExtractToFacts(ctx context.Context, episode types.Episode, opti
 						Model:             extModel,
 						ChunkIndex:        chunkIdx,
 						CreatedAt:         time.Now(),
+						Structured:        r.Structured,
+						StructureStatus:   r.StructureStatus,
+						StructureError:    r.StructureError,
 					})
 				}
 			}
@@ -665,15 +677,10 @@ func (c *Client) PromoteToGraph(ctx context.Context, sourceID string, options *A
 			Embedding:  rule.Embedding,
 			GroupID:    source.GroupID,
 			SourceIDs:  []string{source.ID},
-			Metadata: map[string]interface{}{
-				"scope":              rule.Scope,
-				"source_attribution": rule.SourceAttribution,
-				"confidence":         rule.Confidence,
-				"source_id":          rule.SourceID,
-			},
-			CreatedAt: time.Now(),
-			UpdatedAt: time.Now(),
-			ValidFrom: time.Now(),
+			Metadata:   buildRuleMetadata(rule, source.ID),
+			CreatedAt:  time.Now(),
+			UpdatedAt:  time.Now(),
+			ValidFrom:  time.Now(),
 		}
 		ruleNodes = append(ruleNodes, ruleNode)
 
@@ -1098,14 +1105,10 @@ func (c *Client) PromoteToGraphBatched(ctx context.Context, sourceID string, bat
 				Embedding:  rule.Embedding,
 				GroupID:    source.GroupID,
 				SourceIDs:  []string{sourceID},
-				Metadata: map[string]interface{}{
-					"scope":              rule.Scope,
-					"source_attribution": rule.SourceAttribution,
-					"confidence":         rule.Confidence,
-				},
-				CreatedAt: rule.CreatedAt,
-				UpdatedAt: rule.CreatedAt,
-				ValidFrom: rule.CreatedAt,
+				Metadata:   buildRuleMetadata(rule, sourceID),
+				CreatedAt:  rule.CreatedAt,
+				UpdatedAt:  rule.CreatedAt,
+				ValidFrom:  rule.CreatedAt,
 			}
 			ruleNodes = append(ruleNodes, ruleNode)
 		}
@@ -1179,6 +1182,36 @@ func buildRuleContent(rule *types.ExtractedRule) string {
 	}
 	b, _ := json.Marshal(m)
 	return string(b)
+}
+
+func buildRuleMetadata(rule *types.ExtractedRule, sourceID string) map[string]interface{} {
+	metadata := map[string]interface{}{
+		"scope":              rule.Scope,
+		"source_attribution": rule.SourceAttribution,
+		"confidence":         rule.Confidence,
+		"source_id":          sourceID,
+	}
+	if rule.SourceID != "" {
+		metadata["source_id"] = rule.SourceID
+	}
+	if rule.StructureStatus != "" {
+		metadata["structure_status"] = rule.StructureStatus
+	}
+	if rule.StructureError != "" {
+		metadata["structure_error"] = rule.StructureError
+	}
+	if rule.Structured != nil {
+		if data, err := json.Marshal(rule.Structured); err == nil {
+			metadata["structured_rule"] = string(data)
+			if _, ok := metadata["structure_status"]; !ok {
+				metadata["structure_status"] = ruleschema.StructureStatusParsed
+			}
+		} else {
+			metadata["structure_status"] = ruleschema.StructureStatusInvalid
+			metadata["structure_error"] = err.Error()
+		}
+	}
+	return metadata
 }
 
 // matchEntitiesInText performs case-insensitive substring matching of node names

--- a/pkg/driver/ladybug.go
+++ b/pkg/driver/ladybug.go
@@ -22,6 +22,7 @@ import (
 	ladybug "github.com/LadybugDB/go-ladybug"
 	"github.com/parquet-go/parquet-go"
 
+	"github.com/soundprediction/predicato/pkg/ruleschema"
 	"github.com/soundprediction/predicato/pkg/types"
 )
 
@@ -2560,18 +2561,7 @@ func (k *LadybugDriver) BulkLoadFromParquet(ctx context.Context, inputDir, group
 				if r.Exception != "" {
 					fact += " UNLESS " + r.Exception
 				}
-				attrs := "{}"
-				if data, err := json.Marshal(map[string]any{
-					"antecedent":         r.Antecedent,
-					"consequent":         r.Consequent,
-					"exception":          r.Exception,
-					"rule_type":          r.RuleType,
-					"scope":              r.Scope,
-					"source_attribution": r.SourceAttribution,
-					"confidence":         r.Confidence,
-				}); err == nil {
-					attrs = string(data)
-				}
+				attrs := buildRuleAttributes(r)
 				rules[i] = ladybugRule{
 					Uuid:          r.ID,
 					Name:          r.RuleType + ": " + r.Antecedent,
@@ -2943,18 +2933,7 @@ func (k *LadybugDriver) BulkLoadFromParquetWithFilter(ctx context.Context, input
 			if r.Exception != "" {
 				fact += " UNLESS " + r.Exception
 			}
-			attrs := "{}"
-			if data, err := json.Marshal(map[string]any{
-				"antecedent":         r.Antecedent,
-				"consequent":         r.Consequent,
-				"exception":          r.Exception,
-				"rule_type":          r.RuleType,
-				"scope":              r.Scope,
-				"source_attribution": r.SourceAttribution,
-				"confidence":         r.Confidence,
-			}); err == nil {
-				attrs = string(data)
-			}
+			attrs := buildRuleAttributes(r)
 			rules[i] = ladybugRule{
 				Uuid:          r.ID,
 				Name:          r.RuleType + ": " + r.Antecedent,
@@ -3065,6 +3044,9 @@ type factstoreRule struct {
 	Embedding         []float32 `parquet:"embedding,list"`
 	Confidence        float64   `parquet:"confidence"`
 	ChunkIndex        int32     `parquet:"chunk_index"`
+	StructuredRule    string    `parquet:"structured_rule"`
+	StructureStatus   string    `parquet:"structure_status"`
+	StructureError    string    `parquet:"structure_error"`
 }
 
 func buildTripleAttributes(t factstoreTriple) string {
@@ -3095,6 +3077,35 @@ func buildTripleAttributes(t factstoreTriple) string {
 	}
 	if t.ObjectType != "" {
 		attrs["object_type"] = t.ObjectType
+	}
+	data, err := json.Marshal(attrs)
+	if err != nil {
+		return "{}"
+	}
+	return string(data)
+}
+
+func buildRuleAttributes(r factstoreRule) string {
+	attrs := map[string]any{
+		"antecedent":         r.Antecedent,
+		"consequent":         r.Consequent,
+		"exception":          r.Exception,
+		"rule_type":          r.RuleType,
+		"scope":              r.Scope,
+		"source_attribution": r.SourceAttribution,
+		"confidence":         r.Confidence,
+	}
+	if r.StructuredRule != "" {
+		attrs["structured_rule"] = r.StructuredRule
+		if r.StructureStatus == "" {
+			attrs["structure_status"] = ruleschema.StructureStatusParsed
+		}
+	}
+	if r.StructureStatus != "" {
+		attrs["structure_status"] = r.StructureStatus
+	}
+	if r.StructureError != "" {
+		attrs["structure_error"] = r.StructureError
 	}
 	data, err := json.Marshal(attrs)
 	if err != nil {

--- a/pkg/factstore/postgres.go
+++ b/pkg/factstore/postgres.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	_ "github.com/lib/pq"
+	"github.com/soundprediction/predicato/pkg/ruleschema"
 	"github.com/soundprediction/predicato/pkg/utils"
 )
 
@@ -209,6 +210,10 @@ func (p *PostgresDB) Initialize(ctx context.Context) error {
 			confidence FLOAT,
 			embedding vector(%d),
 			chunk_index INT,
+			model VARCHAR(255),
+			structured_rule TEXT,
+			structure_status TEXT,
+			structure_error TEXT,
 			created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 		)`, p.embeddingDimensions)
 	if _, err := p.db.ExecContext(ctx, rulesTable); err != nil {
@@ -262,6 +267,18 @@ func (p *PostgresDB) Initialize(ctx context.Context) error {
 	for _, migration := range modelMigrations {
 		if _, err := p.db.ExecContext(ctx, migration); err != nil {
 			fmt.Printf("Warning: failed to add model column: %v\n", err)
+		}
+	}
+
+	// --- Structured rule migration ---
+	ruleStructureMigrations := []string{
+		`ALTER TABLE extracted_rules ADD COLUMN IF NOT EXISTS structured_rule TEXT`,
+		`ALTER TABLE extracted_rules ADD COLUMN IF NOT EXISTS structure_status TEXT`,
+		`ALTER TABLE extracted_rules ADD COLUMN IF NOT EXISTS structure_error TEXT`,
+	}
+	for _, migration := range ruleStructureMigrations {
+		if _, err := p.db.ExecContext(ctx, migration); err != nil {
+			fmt.Printf("Warning: failed to add rule structure column: %v\n", err)
 		}
 	}
 
@@ -662,8 +679,8 @@ func (p *PostgresDB) SaveExtractedRules(ctx context.Context, sourceID string, ru
 	defer func() { _ = tx.Rollback() }()
 
 	stmt, err := tx.PrepareContext(ctx, `
-		INSERT INTO extracted_rules (id, source_id, antecedent, consequent, exception, rule_type, scope, source_attribution, confidence, embedding, chunk_index, model, created_at)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
+		INSERT INTO extracted_rules (id, source_id, antecedent, consequent, exception, rule_type, scope, source_attribution, confidence, embedding, chunk_index, model, structured_rule, structure_status, structure_error, created_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)
 		ON CONFLICT (id) DO UPDATE SET
 			antecedent = EXCLUDED.antecedent,
 			consequent = EXCLUDED.consequent,
@@ -674,7 +691,10 @@ func (p *PostgresDB) SaveExtractedRules(ctx context.Context, sourceID string, ru
 			confidence = EXCLUDED.confidence,
 			embedding = EXCLUDED.embedding,
 			chunk_index = EXCLUDED.chunk_index,
-			model = EXCLUDED.model`)
+			model = EXCLUDED.model,
+			structured_rule = EXCLUDED.structured_rule,
+			structure_status = EXCLUDED.structure_status,
+			structure_error = EXCLUDED.structure_error`)
 	if err != nil {
 		return fmt.Errorf("failed to prepare rule statement: %w", err)
 	}
@@ -689,11 +709,16 @@ func (p *PostgresDB) SaveExtractedRules(ctx context.Context, sourceID string, ru
 		if createdAt.IsZero() {
 			createdAt = time.Now()
 		}
+		structuredRule, structureStatus, structureError, err := marshalRuleStructureForDB(r)
+		if err != nil {
+			return fmt.Errorf("failed to marshal structured rule %s: %w", r.ID, err)
+		}
 
 		if _, err := stmt.ExecContext(ctx,
 			r.ID, sourceID, r.Antecedent, r.Consequent, r.Exception,
 			r.RuleType, r.Scope, r.SourceAttribution,
-			r.Confidence, embeddingVal, r.ChunkIndex, r.Model, createdAt); err != nil {
+			r.Confidence, embeddingVal, r.ChunkIndex, r.Model, structuredRule,
+			structureStatus, structureError, createdAt); err != nil {
 			return fmt.Errorf("failed to insert rule %s: %w", r.ID, err)
 		}
 	}
@@ -704,27 +729,51 @@ func (p *PostgresDB) SaveExtractedRules(ctx context.Context, sourceID string, ru
 func (p *PostgresDB) GetExtractedRules(ctx context.Context, sourceID string) ([]*ExtractedRule, error) {
 	rows, err := p.db.QueryContext(ctx, `
 		SELECT id, source_id, antecedent, consequent, exception, rule_type, scope,
-		       source_attribution, confidence, embedding, chunk_index, model, created_at
+		       source_attribution, confidence, embedding, chunk_index, model,
+		       structured_rule, structure_status, structure_error, created_at
 		FROM extracted_rules WHERE source_id = $1`, sourceID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query extracted rules: %w", err)
 	}
 	defer rows.Close()
 
+	return p.scanRuleRows(rows)
+}
+
+func marshalRuleStructureForDB(r *ExtractedRule) (any, string, string, error) {
+	status := r.StructureStatus
+	errText := r.StructureError
+	if r.Structured == nil {
+		if status == "" {
+			status = ruleschema.StructureStatusUnparsed
+		}
+		return nil, status, errText, nil
+	}
+
+	data, err := json.Marshal(r.Structured)
+	if err != nil {
+		return nil, ruleschema.StructureStatusInvalid, err.Error(), err
+	}
+	if status == "" {
+		status = ruleschema.StructureStatusParsed
+	}
+	return string(data), status, errText, nil
+}
+
+func (p *PostgresDB) scanRuleRows(rows *sql.Rows) ([]*ExtractedRule, error) {
 	var rules []*ExtractedRule
 	for rows.Next() {
 		var r ExtractedRule
 		var embeddingStr sql.NullString
 		var exception, ruleType, scope, sourceAttr sql.NullString
+		var model, structuredRule, structureStatus, structureError sql.NullString
 		var confidence sql.NullFloat64
-
-		var model sql.NullString
 		if err := rows.Scan(&r.ID, &r.SourceID, &r.Antecedent, &r.Consequent,
 			&exception, &ruleType, &scope, &sourceAttr,
-			&confidence, &embeddingStr, &r.ChunkIndex, &model, &r.CreatedAt); err != nil {
+			&confidence, &embeddingStr, &r.ChunkIndex, &model,
+			&structuredRule, &structureStatus, &structureError, &r.CreatedAt); err != nil {
 			return nil, err
 		}
-
 		if exception.Valid {
 			r.Exception = exception.String
 		}
@@ -746,8 +795,36 @@ func (p *PostgresDB) GetExtractedRules(ctx context.Context, sourceID string) ([]
 		if model.Valid {
 			r.Model = model.String
 		}
-
+		if structureStatus.Valid {
+			r.StructureStatus = structureStatus.String
+		}
+		if structureError.Valid {
+			r.StructureError = structureError.String
+		}
+		if structuredRule.Valid && strings.TrimSpace(structuredRule.String) != "" {
+			var structured ruleschema.Rule
+			if err := json.Unmarshal([]byte(structuredRule.String), &structured); err != nil {
+				if r.StructureStatus == "" {
+					r.StructureStatus = ruleschema.StructureStatusInvalid
+				}
+				if r.StructureError == "" {
+					r.StructureError = err.Error()
+				}
+			} else {
+				r.Structured = &structured
+			}
+		}
+		if r.StructureStatus == "" {
+			if r.Structured != nil {
+				r.StructureStatus = ruleschema.StructureStatusParsed
+			} else {
+				r.StructureStatus = ruleschema.StructureStatusUnparsed
+			}
+		}
 		rules = append(rules, &r)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
 	}
 	return rules, nil
 }
@@ -791,7 +868,8 @@ func (p *PostgresDB) GetExtractedTriplesPaginated(ctx context.Context, sourceID 
 func (p *PostgresDB) GetExtractedRulesPaginated(ctx context.Context, sourceID string, offset, limit int) ([]*ExtractedRule, error) {
 	rows, err := p.db.QueryContext(ctx, `
 		SELECT id, source_id, antecedent, consequent, exception, rule_type, scope,
-		       source_attribution, confidence, embedding, chunk_index, model, created_at
+		       source_attribution, confidence, embedding, chunk_index, model,
+		       structured_rule, structure_status, structure_error, created_at
 		FROM extracted_rules WHERE source_id = $1
 		ORDER BY id
 		LIMIT $2 OFFSET $3`, sourceID, limit, offset)
@@ -800,42 +878,7 @@ func (p *PostgresDB) GetExtractedRulesPaginated(ctx context.Context, sourceID st
 	}
 	defer rows.Close()
 
-	var rules []*ExtractedRule
-	for rows.Next() {
-		var r ExtractedRule
-		var embeddingStr sql.NullString
-		var exception, ruleType, scope, sourceAttr sql.NullString
-		var confidence sql.NullFloat64
-		var model sql.NullString
-		if err := rows.Scan(&r.ID, &r.SourceID, &r.Antecedent, &r.Consequent,
-			&exception, &ruleType, &scope, &sourceAttr,
-			&confidence, &embeddingStr, &r.ChunkIndex, &model, &r.CreatedAt); err != nil {
-			return nil, err
-		}
-		if exception.Valid {
-			r.Exception = exception.String
-		}
-		if ruleType.Valid {
-			r.RuleType = ruleType.String
-		}
-		if scope.Valid {
-			r.Scope = scope.String
-		}
-		if sourceAttr.Valid {
-			r.SourceAttribution = sourceAttr.String
-		}
-		if confidence.Valid {
-			r.Confidence = confidence.Float64
-		}
-		if embeddingStr.Valid {
-			r.Embedding = p.parseEmbedding(embeddingStr.String)
-		}
-		if model.Valid {
-			r.Model = model.String
-		}
-		rules = append(rules, &r)
-	}
-	return rules, nil
+	return p.scanRuleRows(rows)
 }
 
 func (p *PostgresDB) CountExtractedNodes(ctx context.Context, sourceID string) (int64, error) {

--- a/pkg/nlp/client_types.go
+++ b/pkg/nlp/client_types.go
@@ -1,5 +1,7 @@
 package nlp
 
+import "github.com/soundprediction/predicato/pkg/ruleschema"
+
 // ExtractedEntity represents an entity extracted from text by an NLP model.
 type ExtractedEntity struct {
 	Text       string  `json:"text"`
@@ -33,13 +35,16 @@ type ExtendedTriple struct {
 
 // Rule represents a conditional rule: IF antecedent THEN consequent [UNLESS exception].
 type Rule struct {
-	Antecedent        string  `json:"antecedent"`
-	Consequent        string  `json:"consequent"`
-	Exception         string  `json:"exception,omitempty"`
-	RuleType          string  `json:"rule_type,omitempty"`
-	Scope             string  `json:"scope,omitempty"`
-	SourceAttribution string  `json:"source_attribution,omitempty"`
-	Confidence        float64 `json:"confidence,omitempty"`
+	Antecedent        string           `json:"antecedent"`
+	Consequent        string           `json:"consequent"`
+	Exception         string           `json:"exception,omitempty"`
+	RuleType          string           `json:"rule_type,omitempty"`
+	Scope             string           `json:"scope,omitempty"`
+	SourceAttribution string           `json:"source_attribution,omitempty"`
+	Confidence        float64          `json:"confidence,omitempty"`
+	Structured        *ruleschema.Rule `json:"structured,omitempty"`
+	StructureStatus   string           `json:"structure_status,omitempty"`
+	StructureError    string           `json:"structure_error,omitempty"`
 }
 
 // ExtendedExtractionResult represents the full extraction output including extended triples and rules.

--- a/pkg/nlp/llm_helpers.go
+++ b/pkg/nlp/llm_helpers.go
@@ -59,7 +59,7 @@ func calculateProgressiveTimeout(attempt int) time.Duration {
 //	jsonStr, err := GenerateJSONResponseWithContinuation(
 //	    ctx, nlProcessor,
 //	    "You are a JSON generator. Return only valid JSON.",
-//	    "Generate a list of 10 pregnancy tips",
+//	    "Generate a list of 10 onboarding tips",
 //	    &result,
 //	    5,
 //	)
@@ -707,46 +707,96 @@ Extract the following:
    Context fields (condition, temporal, scope, etc.) should be exact substrings where possible.
 4. Rules (extractive): Conditional logic STATED in the text. The antecedent and consequent must
    be exact substrings or contiguous phrases copied from the text.
-5. Inferred rules: Clinical knowledge implied by the text but not stated verbatim. These go in
+5. Inferred rules: Knowledge implied by the text but not stated verbatim. These go in
    a SEPARATE "inferred_rules" array.
 
 Return the output as a JSON object matching this structure:
 {
   "source_text": "Original text segment",
   "entities": { "type": ["entity1", "entity2"] },
-  "relations": [ { "source": "A", "target": "B", "type": "treats", "confidence": 1.0 } ],
+  "relations": [ { "source": "A", "target": "B", "type": "depends_on", "confidence": 1.0 } ],
   "triples": [
     {
-      "subject": "Metformin", "predicate": "reduces", "object": "blood glucose levels",
-      "condition": "in patients with type 2 diabetes", "temporal": "", "location": "",
-      "certainty": "established", "scope": "adults with type 2 diabetes", "source_attribution": ""
+      "subject": "request", "predicate": "requires", "object": "approval",
+      "condition": "when the amount exceeds the limit", "temporal": "", "location": "",
+      "certainty": "stated", "scope": "approval workflow", "source_attribution": ""
     }
   ],
   "rules": [
     {
-      "antecedent": "fasting glucose exceeds 95 mg/dL on two or more occasions",
-      "consequent": "insulin therapy should be initiated",
-      "exception": "unless contraindicated due to renal impairment",
-      "rule_type": "clinical_decision",
-      "scope": "gestational diabetes",
-      "source_attribution": ""
+      "antecedent": "the request amount exceeds the approval limit",
+      "consequent": "manager approval is required",
+      "exception": "unless the requester has pre-approval",
+      "rule_type": "policy_rule",
+      "scope": "approval workflow",
+      "source_attribution": "",
+      "structured": {
+        "schema_version": 1,
+        "conditions": [
+          {
+            "id": "c1",
+            "subject": { "var": "x" },
+            "predicate": "exceeds",
+            "predicate_canonical": "exceeds",
+            "object": { "entity": "approval limit", "entity_type": "threshold" }
+          }
+        ],
+        "consequent": {
+          "id": "k1",
+          "subject": { "var": "x" },
+          "predicate": "requires",
+          "predicate_canonical": "requires",
+          "object": { "entity": "manager approval" }
+        },
+        "exceptions": [
+          {
+            "id": "e1",
+            "subject": { "var": "x" },
+            "predicate": "has",
+            "object": { "entity": "pre-approval" }
+          }
+        ]
+      }
     }
   ],
   "inferred_rules": [
     {
-      "antecedent": "Patient has uncontrolled gestational diabetes",
-      "consequent": "Monitor for fetal macrosomia",
-      "rule_type": "clinical_inference",
-      "scope": "gestational diabetes",
-      "source_attribution": ""
+      "antecedent": "A task is blocked by a missing approval",
+      "consequent": "The task should be escalated to the owner",
+      "rule_type": "inference_rule",
+      "scope": "approval workflow",
+      "source_attribution": "",
+      "structured": {
+        "schema_version": 1,
+        "conditions": [
+          {
+            "id": "c1",
+            "subject": { "var": "task" },
+            "predicate": "blocked_by",
+            "object": { "entity": "missing approval" }
+          }
+        ],
+        "consequent": {
+          "id": "k1",
+          "subject": { "var": "task" },
+          "predicate": "escalated_to",
+          "object": { "entity": "owner" }
+        },
+        "exceptions": []
+      }
     }
   ]
 }
 
 IMPORTANT:
 - "rules" array: antecedent/consequent/exception MUST appear verbatim in the source text.
-- "inferred_rules" array: paraphrased clinical knowledge derived from the text.
+- "inferred_rules" array: paraphrased knowledge derived from the text.
 - Entity names, relation source/target, and triple subject/object must ALWAYS be exact substrings.
+- For every rule, include the existing text fields AND, when possible, a "structured" object.
+- structured.conditions, structured.consequent, and structured.exceptions MUST use subject/predicate/object patterns.
+- Pattern terms MUST be either variables like { "var": "x" } or constants like { "entity": "approval limit", "entity_uuid": "", "entity_type": "threshold" }.
+- Use the same variable name across related patterns. Every variable in structured.consequent or structured.exceptions MUST also appear in structured.conditions.
+- If a rule cannot be represented confidently as structured patterns, omit "structured" and still return the text rule.
 `, entityGuidance, relationGuidance)
 
 	userPrompt := fmt.Sprintf("Extract structured information from the following text:\n\n%s", text)
@@ -775,6 +825,7 @@ IMPORTANT:
 	if result.SourceText == "" {
 		result.SourceText = text
 	}
+	CompileExtendedExtractionRuleStructures(&result)
 
 	return &result, nil
 }

--- a/pkg/nlp/llm_helpers_test.go
+++ b/pkg/nlp/llm_helpers_test.go
@@ -30,7 +30,7 @@ func ExampleGenerateJSONResponseWithContinuation() {
 	// 	context.Background(),
 	// 	nlProcessor,
 	// 	"You are a helpful assistant that returns only valid JSON.",
-	// 	"Generate a JSON object with pregnancy nutrition tips",
+	// 	"Generate a JSON object with onboarding tips",
 	// 	&result,
 	// 	5, // max retries
 	// )
@@ -52,7 +52,7 @@ func ExampleGenerateJSONWithContinuation() {
 	// 	context.Background(),
 	// 	nlProcessor,
 	// 	"Return only valid JSON.",
-	// 	"List 5 pregnancy exercises as JSON array",
+	// 	"List 5 onboarding tasks as JSON array",
 	// 	3,
 	// )
 	//

--- a/pkg/nlp/rule_structure.go
+++ b/pkg/nlp/rule_structure.go
@@ -1,0 +1,83 @@
+package nlp
+
+import "github.com/soundprediction/predicato/pkg/ruleschema"
+
+// RuleStructureMetadata contains provenance known outside the LLM response.
+type RuleStructureMetadata struct {
+	ID            string
+	SourceID      string
+	Model         string
+	ChunkIndex    int
+	HasChunkIndex bool
+}
+
+// CompileRuleStructure validates a rule's optional structured form.
+//
+// Text-only rules are preserved with structure_status="unparsed". If structured
+// patterns are present but invalid, Structured is cleared and the text rule is
+// preserved with structure_status="invalid".
+func CompileRuleStructure(rule *Rule, meta RuleStructureMetadata) {
+	if rule == nil {
+		return
+	}
+	if rule.Structured == nil {
+		rule.StructureStatus = ruleschema.StructureStatusUnparsed
+		rule.StructureError = ""
+		return
+	}
+
+	structured := *rule.Structured
+	applyRuleStructureMetadata(&structured, *rule, meta)
+	ruleschema.Normalize(&structured)
+	if err := ruleschema.Validate(structured); err != nil {
+		rule.Structured = nil
+		rule.StructureStatus = ruleschema.StructureStatusInvalid
+		rule.StructureError = err.Error()
+		return
+	}
+
+	rule.Structured = &structured
+	rule.StructureStatus = ruleschema.StructureStatusParsed
+	rule.StructureError = ""
+}
+
+// CompileExtendedExtractionRuleStructures validates all optional structured
+// rules in an extraction result.
+func CompileExtendedExtractionRuleStructures(result *ExtendedExtractionResult) {
+	if result == nil {
+		return
+	}
+	for i := range result.Rules {
+		CompileRuleStructure(&result.Rules[i], RuleStructureMetadata{})
+	}
+	for i := range result.InferredRules {
+		CompileRuleStructure(&result.InferredRules[i], RuleStructureMetadata{})
+	}
+}
+
+func applyRuleStructureMetadata(dst *ruleschema.Rule, src Rule, meta RuleStructureMetadata) {
+	if meta.ID != "" {
+		dst.ID = meta.ID
+	}
+	if dst.RuleType == "" {
+		dst.RuleType = src.RuleType
+	}
+	if dst.Scope == "" {
+		dst.Scope = src.Scope
+	}
+	if dst.Confidence == 0 && src.Confidence != 0 {
+		dst.Confidence = src.Confidence
+	}
+	if meta.SourceID != "" {
+		dst.Provenance.SourceID = meta.SourceID
+	}
+	if meta.Model != "" {
+		dst.Provenance.Model = meta.Model
+	}
+	if meta.HasChunkIndex {
+		dst.Provenance.ChunkIndex = meta.ChunkIndex
+	}
+	if dst.Provenance.SourceAttribution == "" {
+		dst.Provenance.SourceAttribution = src.SourceAttribution
+	}
+}

--- a/pkg/nlp/rule_structure_test.go
+++ b/pkg/nlp/rule_structure_test.go
@@ -1,0 +1,134 @@
+package nlp_test
+
+import (
+	"testing"
+
+	"github.com/soundprediction/predicato/pkg/nlp"
+	"github.com/soundprediction/predicato/pkg/ruleschema"
+)
+
+func structuredRule() *ruleschema.Rule {
+	return &ruleschema.Rule{
+		Conditions: []ruleschema.Pattern{
+			{
+				ID:        "c1",
+				Subject:   ruleschema.Term{Var: "?x"},
+				Predicate: "has_state",
+				Object:    ruleschema.Term{Entity: "ready"},
+			},
+		},
+		Consequent: ruleschema.Pattern{
+			ID:        "k1",
+			Subject:   ruleschema.Term{Var: "x"},
+			Predicate: "can_start",
+			Object:    ruleschema.Term{Entity: "workflow"},
+		},
+	}
+}
+
+func TestCompileRuleStructureParsed(t *testing.T) {
+	rule := nlp.Rule{
+		Antecedent:        "item is ready",
+		Consequent:        "workflow can start",
+		RuleType:          "policy",
+		Scope:             "operations",
+		SourceAttribution: "paragraph 2",
+		Confidence:        0.8,
+		Structured:        structuredRule(),
+	}
+
+	nlp.CompileRuleStructure(&rule, nlp.RuleStructureMetadata{
+		ID:            "rule-1",
+		SourceID:      "source-1",
+		Model:         "model-a",
+		ChunkIndex:    3,
+		HasChunkIndex: true,
+	})
+
+	if rule.StructureStatus != ruleschema.StructureStatusParsed {
+		t.Fatalf("StructureStatus = %q, want %q", rule.StructureStatus, ruleschema.StructureStatusParsed)
+	}
+	if rule.StructureError != "" {
+		t.Fatalf("StructureError = %q, want empty", rule.StructureError)
+	}
+	if rule.Structured == nil {
+		t.Fatal("Structured was cleared")
+	}
+	if rule.Structured.ID != "rule-1" {
+		t.Fatalf("structured ID = %q, want rule-1", rule.Structured.ID)
+	}
+	if rule.Structured.Conditions[0].Subject.Var != "x" {
+		t.Fatalf("condition variable = %q, want x", rule.Structured.Conditions[0].Subject.Var)
+	}
+	if rule.Structured.RuleType != "policy" {
+		t.Fatalf("rule_type = %q, want policy", rule.Structured.RuleType)
+	}
+	if rule.Structured.Provenance.SourceID != "source-1" {
+		t.Fatalf("source_id = %q, want source-1", rule.Structured.Provenance.SourceID)
+	}
+	if err := ruleschema.Validate(*rule.Structured); err != nil {
+		t.Fatalf("structured rule did not validate: %v", err)
+	}
+}
+
+func TestCompileRuleStructureTextOnlyFallback(t *testing.T) {
+	rule := nlp.Rule{
+		Antecedent: "item is ready",
+		Consequent: "workflow can start",
+	}
+
+	nlp.CompileRuleStructure(&rule, nlp.RuleStructureMetadata{})
+
+	if rule.StructureStatus != ruleschema.StructureStatusUnparsed {
+		t.Fatalf("StructureStatus = %q, want %q", rule.StructureStatus, ruleschema.StructureStatusUnparsed)
+	}
+	if rule.Structured != nil {
+		t.Fatal("Structured set for text-only rule")
+	}
+	if rule.Antecedent == "" || rule.Consequent == "" {
+		t.Fatal("text rule fields were dropped")
+	}
+}
+
+func TestCompileRuleStructureInvalid(t *testing.T) {
+	invalid := structuredRule()
+	invalid.Consequent.Subject = ruleschema.Term{Var: "missing"}
+	rule := nlp.Rule{
+		Antecedent: "item is ready",
+		Consequent: "workflow can start",
+		Structured: invalid,
+	}
+
+	nlp.CompileRuleStructure(&rule, nlp.RuleStructureMetadata{})
+
+	if rule.StructureStatus != ruleschema.StructureStatusInvalid {
+		t.Fatalf("StructureStatus = %q, want %q", rule.StructureStatus, ruleschema.StructureStatusInvalid)
+	}
+	if rule.StructureError == "" {
+		t.Fatal("StructureError is empty for invalid structure")
+	}
+	if rule.Structured != nil {
+		t.Fatal("Structured was not cleared for invalid structure")
+	}
+	if rule.Antecedent == "" || rule.Consequent == "" {
+		t.Fatal("text rule fields were dropped")
+	}
+}
+
+func TestCompileExtendedExtractionRuleStructures(t *testing.T) {
+	result := &nlp.ExtendedExtractionResult{
+		Rules: []nlp.Rule{
+			{Antecedent: "if A", Consequent: "then B", Structured: structuredRule()},
+			{Antecedent: "if C", Consequent: "then D"},
+		},
+	}
+
+	nlp.CompileExtendedExtractionRuleStructures(result)
+
+	if result.Rules[0].StructureStatus != ruleschema.StructureStatusParsed {
+		t.Fatalf("structured rule status = %q", result.Rules[0].StructureStatus)
+	}
+	if result.Rules[1].StructureStatus != ruleschema.StructureStatusUnparsed {
+		t.Fatalf("text-only rule status = %q", result.Rules[1].StructureStatus)
+	}
+}

--- a/pkg/ruleschema/schema.go
+++ b/pkg/ruleschema/schema.go
@@ -1,0 +1,219 @@
+package ruleschema
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+const (
+	// CurrentSchemaVersion is the rule contract version emitted by predicato.
+	CurrentSchemaVersion = 1
+
+	// StructureStatusParsed means a structured rule was present and validated.
+	StructureStatusParsed = "parsed"
+	// StructureStatusUnparsed means the text rule had no structured patterns.
+	StructureStatusUnparsed = "unparsed"
+	// StructureStatusInvalid means structured patterns were present but invalid.
+	StructureStatusInvalid = "invalid"
+)
+
+// Term is either a variable or a constant entity reference.
+type Term struct {
+	Var        string `json:"var,omitempty"`
+	Entity     string `json:"entity,omitempty"`
+	EntityUUID string `json:"entity_uuid,omitempty"`
+	EntityType string `json:"entity_type,omitempty"`
+}
+
+// Pattern is a subject-predicate-object clause in a conditional rule.
+type Pattern struct {
+	ID                 string `json:"id"`
+	Subject            Term   `json:"subject"`
+	Predicate          string `json:"predicate"`
+	PredicateCanonical string `json:"predicate_canonical,omitempty"`
+	Object             Term   `json:"object"`
+	Negated            bool   `json:"negated,omitempty"`
+}
+
+// Provenance captures source metadata for an extracted structured rule.
+type Provenance struct {
+	SourceID          string `json:"source_id"`
+	ChunkIndex        int    `json:"chunk_index"`
+	Model             string `json:"model"`
+	SourceAttribution string `json:"source_attribution"`
+}
+
+// Rule is the versioned, domain-agnostic JSON contract for conditional rules.
+type Rule struct {
+	SchemaVersion int        `json:"schema_version"`
+	ID            string     `json:"id"`
+	RuleType      string     `json:"rule_type"`
+	Scope         string     `json:"scope"`
+	Confidence    float64    `json:"confidence"`
+	Conditions    []Pattern  `json:"conditions"`
+	Consequent    Pattern    `json:"consequent"`
+	Exceptions    []Pattern  `json:"exceptions"`
+	Provenance    Provenance `json:"provenance"`
+}
+
+// MarshalJSON emits the current schema version when SchemaVersion is unset.
+func (r Rule) MarshalJSON() ([]byte, error) {
+	type alias Rule
+	Normalize(&r)
+	return json.Marshal(alias(r))
+}
+
+// UnmarshalJSON accepts missing schema_version and defaults it to the current version.
+func (r *Rule) UnmarshalJSON(data []byte) error {
+	type alias Rule
+	var decoded alias
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return err
+	}
+	*r = Rule(decoded)
+	Normalize(r)
+	return nil
+}
+
+// Normalize fills default fields and canonicalizes whitespace/variable spelling.
+func Normalize(r *Rule) {
+	if r == nil {
+		return
+	}
+	if r.SchemaVersion == 0 {
+		r.SchemaVersion = CurrentSchemaVersion
+	}
+	r.ID = strings.TrimSpace(r.ID)
+	r.RuleType = strings.TrimSpace(r.RuleType)
+	r.Scope = strings.TrimSpace(r.Scope)
+	r.Provenance.SourceID = strings.TrimSpace(r.Provenance.SourceID)
+	r.Provenance.Model = strings.TrimSpace(r.Provenance.Model)
+	r.Provenance.SourceAttribution = strings.TrimSpace(r.Provenance.SourceAttribution)
+	for i := range r.Conditions {
+		normalizePattern(&r.Conditions[i])
+	}
+	normalizePattern(&r.Consequent)
+	for i := range r.Exceptions {
+		normalizePattern(&r.Exceptions[i])
+	}
+}
+
+// Validate enforces the structural invariants for a rule.
+func Validate(r Rule) error {
+	Normalize(&r)
+	if r.SchemaVersion != CurrentSchemaVersion {
+		return fmt.Errorf("unsupported schema_version %d", r.SchemaVersion)
+	}
+	if len(r.Conditions) == 0 {
+		return errors.New("rule must include at least one condition")
+	}
+
+	conditionVars := make(map[string]struct{})
+	for i, condition := range r.Conditions {
+		path := fmt.Sprintf("conditions[%d]", i)
+		if err := validatePattern(condition, path); err != nil {
+			return err
+		}
+		addPatternVars(condition, conditionVars)
+	}
+
+	if err := validatePattern(r.Consequent, "consequent"); err != nil {
+		return err
+	}
+	if err := validateRangeRestricted(r.Consequent, conditionVars, "consequent"); err != nil {
+		return err
+	}
+
+	for i, exception := range r.Exceptions {
+		path := fmt.Sprintf("exceptions[%d]", i)
+		if err := validatePattern(exception, path); err != nil {
+			return err
+		}
+		if err := validateRangeRestricted(exception, conditionVars, path); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func normalizePattern(p *Pattern) {
+	p.ID = strings.TrimSpace(p.ID)
+	p.Predicate = strings.TrimSpace(p.Predicate)
+	p.PredicateCanonical = strings.TrimSpace(p.PredicateCanonical)
+	normalizeTerm(&p.Subject)
+	normalizeTerm(&p.Object)
+}
+
+func normalizeTerm(t *Term) {
+	t.Var = normalizeVariableName(t.Var)
+	t.Entity = strings.TrimSpace(t.Entity)
+	t.EntityUUID = strings.TrimSpace(t.EntityUUID)
+	t.EntityType = strings.TrimSpace(t.EntityType)
+}
+
+func normalizeVariableName(v string) string {
+	v = strings.TrimSpace(v)
+	v = strings.TrimPrefix(v, "?")
+	return strings.TrimSpace(v)
+}
+
+func validatePattern(p Pattern, path string) error {
+	if strings.TrimSpace(p.Predicate) == "" {
+		return fmt.Errorf("%s.predicate must be non-empty", path)
+	}
+	if err := validateTerm(p.Subject, path+".subject"); err != nil {
+		return err
+	}
+	if err := validateTerm(p.Object, path+".object"); err != nil {
+		return err
+	}
+	return nil
+}
+
+func validateTerm(t Term, path string) error {
+	hasVar := strings.TrimSpace(t.Var) != ""
+	hasEntity := strings.TrimSpace(t.Entity) != ""
+	switch {
+	case hasVar && hasEntity:
+		return fmt.Errorf("%s must set exactly one of var or entity", path)
+	case !hasVar && !hasEntity:
+		return fmt.Errorf("%s must set exactly one of var or entity", path)
+	case hasVar && (strings.TrimSpace(t.EntityUUID) != "" || strings.TrimSpace(t.EntityType) != ""):
+		return fmt.Errorf("%s entity_uuid/entity_type require entity", path)
+	default:
+		return nil
+	}
+}
+
+func addPatternVars(p Pattern, vars map[string]struct{}) {
+	if v, ok := variableName(p.Subject); ok {
+		vars[v] = struct{}{}
+	}
+	if v, ok := variableName(p.Object); ok {
+		vars[v] = struct{}{}
+	}
+}
+
+func validateRangeRestricted(p Pattern, conditionVars map[string]struct{}, path string) error {
+	for termPath, term := range map[string]Term{
+		path + ".subject": p.Subject,
+		path + ".object":  p.Object,
+	} {
+		v, ok := variableName(term)
+		if !ok {
+			continue
+		}
+		if _, found := conditionVars[v]; !found {
+			return fmt.Errorf("%s variable %q must appear in at least one condition", termPath, v)
+		}
+	}
+	return nil
+}
+
+func variableName(t Term) (string, bool) {
+	v := normalizeVariableName(t.Var)
+	return v, v != ""
+}

--- a/pkg/ruleschema/schema_test.go
+++ b/pkg/ruleschema/schema_test.go
@@ -1,0 +1,146 @@
+package ruleschema
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func validRule() Rule {
+	return Rule{
+		ID:         "r1",
+		RuleType:   "policy",
+		Scope:      "general",
+		Confidence: 0.9,
+		Conditions: []Pattern{
+			{
+				ID:        "c1",
+				Subject:   Term{Var: "x"},
+				Predicate: "has_status",
+				Object:    Term{Entity: "active", EntityType: "status"},
+			},
+		},
+		Consequent: Pattern{
+			ID:        "k1",
+			Subject:   Term{Var: "x"},
+			Predicate: "receives",
+			Object:    Term{Entity: "standard review"},
+		},
+		Exceptions: []Pattern{
+			{
+				ID:        "e1",
+				Subject:   Term{Var: "x"},
+				Predicate: "blocked_by",
+				Object:    Term{Entity: "manual hold"},
+				Negated:   true,
+			},
+		},
+		Provenance: Provenance{
+			SourceID:          "source-1",
+			ChunkIndex:        2,
+			Model:             "model-a",
+			SourceAttribution: "section 1",
+		},
+	}
+}
+
+func TestValidateRangeRestrictionPass(t *testing.T) {
+	rule := validRule()
+	if err := Validate(rule); err != nil {
+		t.Fatalf("Validate() returned error: %v", err)
+	}
+}
+
+func TestValidateRangeRestrictionFail(t *testing.T) {
+	rule := validRule()
+	rule.Consequent.Subject = Term{Var: "y"}
+	if err := Validate(rule); err == nil {
+		t.Fatal("Validate() succeeded for consequent variable absent from conditions")
+	}
+}
+
+func TestValidateExceptionRangeRestrictionFail(t *testing.T) {
+	rule := validRule()
+	rule.Exceptions[0].Object = Term{Var: "missing"}
+	if err := Validate(rule); err == nil {
+		t.Fatal("Validate() succeeded for exception variable absent from conditions")
+	}
+}
+
+func TestValidateTermExclusivity(t *testing.T) {
+	tests := []struct {
+		name string
+		term Term
+	}{
+		{name: "both var and entity", term: Term{Var: "x", Entity: "thing"}},
+		{name: "neither var nor entity", term: Term{}},
+		{name: "var with entity metadata", term: Term{Var: "x", EntityUUID: "uuid-1"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rule := validRule()
+			rule.Conditions[0].Subject = tt.term
+			if err := Validate(rule); err == nil {
+				t.Fatal("Validate() succeeded for invalid term")
+			}
+		})
+	}
+}
+
+func TestJSONRoundTripDefaultsSchemaVersion(t *testing.T) {
+	rule := validRule()
+	rule.SchemaVersion = 0
+	rule.Conditions[0].Subject.Var = "?x"
+
+	data, err := json.Marshal(rule)
+	if err != nil {
+		t.Fatalf("Marshal() error: %v", err)
+	}
+
+	var decoded Rule
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("Unmarshal() error: %v", err)
+	}
+	if decoded.SchemaVersion != CurrentSchemaVersion {
+		t.Fatalf("schema version = %d, want %d", decoded.SchemaVersion, CurrentSchemaVersion)
+	}
+	if decoded.Conditions[0].Subject.Var != "x" {
+		t.Fatalf("variable = %q, want %q", decoded.Conditions[0].Subject.Var, "x")
+	}
+	if err := Validate(decoded); err != nil {
+		t.Fatalf("decoded rule did not validate: %v", err)
+	}
+}
+
+func TestStructuredRuleAttributeRoundTrip(t *testing.T) {
+	rule := validRule()
+	structured, err := json.Marshal(rule)
+	if err != nil {
+		t.Fatalf("Marshal(rule) error: %v", err)
+	}
+
+	attributes := map[string]any{
+		"structured_rule":  string(structured),
+		"structure_status": StructureStatusParsed,
+	}
+	encodedAttributes, err := json.Marshal(attributes)
+	if err != nil {
+		t.Fatalf("Marshal(attributes) error: %v", err)
+	}
+
+	var decodedAttributes map[string]string
+	if err := json.Unmarshal(encodedAttributes, &decodedAttributes); err != nil {
+		t.Fatalf("Unmarshal(attributes) error: %v", err)
+	}
+	if decodedAttributes["structure_status"] != StructureStatusParsed {
+		t.Fatalf("structure_status = %q, want %q", decodedAttributes["structure_status"], StructureStatusParsed)
+	}
+
+	var decodedRule Rule
+	if err := json.Unmarshal([]byte(decodedAttributes["structured_rule"]), &decodedRule); err != nil {
+		t.Fatalf("Unmarshal(structured_rule) error: %v", err)
+	}
+	if err := Validate(decodedRule); err != nil {
+		t.Fatalf("decoded structured_rule did not validate: %v", err)
+	}
+}

--- a/pkg/types/extraction.go
+++ b/pkg/types/extraction.go
@@ -2,6 +2,8 @@ package types
 
 import (
 	"time"
+
+	"github.com/soundprediction/predicato/pkg/ruleschema"
 )
 
 // ExtractedNode represents a raw entity extracted from a source.
@@ -121,17 +123,20 @@ func (r *ExtractionResults) RuleCount() int {
 // ExtractedRule represents a conditional rule extracted from a source:
 // IF antecedent THEN consequent [UNLESS exception].
 type ExtractedRule struct {
-	CreatedAt         time.Time `json:"created_at"`
-	ID                string    `json:"id"`
-	SourceID          string    `json:"source_id"`
-	Antecedent        string    `json:"antecedent"`
-	Consequent        string    `json:"consequent"`
-	Exception         string    `json:"exception,omitempty"`
-	RuleType          string    `json:"rule_type,omitempty"`
-	Scope             string    `json:"scope,omitempty"`
-	SourceAttribution string    `json:"source_attribution,omitempty"`
-	Model             string    `json:"model,omitempty"`
-	Embedding         []float32 `json:"embedding,omitempty"`
-	Confidence        float64   `json:"confidence,omitempty"`
-	ChunkIndex        int       `json:"chunk_index"`
+	CreatedAt         time.Time        `json:"created_at"`
+	ID                string           `json:"id"`
+	SourceID          string           `json:"source_id"`
+	Antecedent        string           `json:"antecedent"`
+	Consequent        string           `json:"consequent"`
+	Exception         string           `json:"exception,omitempty"`
+	RuleType          string           `json:"rule_type,omitempty"`
+	Scope             string           `json:"scope,omitempty"`
+	SourceAttribution string           `json:"source_attribution,omitempty"`
+	Model             string           `json:"model,omitempty"`
+	Embedding         []float32        `json:"embedding,omitempty"`
+	Confidence        float64          `json:"confidence,omitempty"`
+	ChunkIndex        int              `json:"chunk_index"`
+	Structured        *ruleschema.Rule `json:"structured,omitempty"`
+	StructureStatus   string           `json:"structure_status,omitempty"`
+	StructureError    string           `json:"structure_error,omitempty"`
 }


### PR DESCRIPTION
Phase 1 of the cross-repo conditional-rule layer (pairs with pensiero's `ConditionalReasoner`). predicato side: **represent + store** structured rules; pensiero imports `pkg/ruleschema` to evaluate them.

## What
- **`pkg/ruleschema`** — domain-agnostic, versioned, stdlib-only contract: `Rule{conditions []Pattern, consequent Pattern, exceptions []Pattern, confidence, …}`, `Pattern{subject Term, predicate, object Term, negated}`, `Term{var | entity constant}`. `Validate` enforces **range-restriction** (every consequent/exception variable must be bound by a condition) + term exclusivity; JSON round-trips with `schema_version` defaulting.
- **Additive wiring** (text fields + IMPLIES edges unchanged): optional `Structured *ruleschema.Rule` + `StructureStatus`/`StructureError` on `nlp.Rule`/`types.ExtractedRule`; compiler marks `parsed|unparsed|invalid` and never drops text-only rules; `extracted_rules` gains `structured_rule`/`structure_status`/`structure_error`; graph promotion + parquet import copy the structured JSON into `Rule.attributes["structured_rule"]`; extraction prompt also requests structured subject/predicate/object patterns (domain-neutral, backward-compatible).

## Verified
`go build ./...`, `go vet`, `go test ./pkg/ruleschema/... ./pkg/nlp/...` pass; `ruleschema.Validate` range-restriction + JSON round-trip + compile-from-extraction tested.

Phase 2 (deferred): query-friendly `RulePattern` graph tables. Pairs with pensiero PR (conditional reasoner). No behavior change until documents are re-ingested with structured extraction.