### PR TITLE
verification: add VerifyBatch (one NLI/embed pass across many claims)

### DIFF
--- a/pkg/verification/verifier.go
+++ b/pkg/verification/verifier.go
@@ -2,6 +2,7 @@ package verification
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 
 	"github.com/soundprediction/predicato/pkg/embedder"
@@ -116,6 +117,102 @@ func (v *Verifier) Verify(ctx context.Context, response string, facts []string, 
 	// 4. Aggregate
 	result := aggregate(verdicts, opts)
 	return result, nil
+}
+
+// VerifyBatch verifies multiple independent (response, facts) units in a single
+// pass, running ONE NLI ClassifyBatch across every gated claim-evidence pair from
+// all units — instead of one ClassifyBatch per unit. It returns one result per
+// unit, in input order; each result is identical to what Verify(responses[u],
+// factsPer[u]) would return, but the (GPU-bound) NLI model is invoked once for the
+// whole batch rather than len(responses) times. This is the amortization the
+// per-claim recheck loop needs: N model-asserted claims cost one forward pass, not
+// N. With a nil NLI client it falls back to embedding-similarity verdicts per unit,
+// exactly like Verify.
+func (v *Verifier) VerifyBatch(ctx context.Context, responses []string, factsPer [][]string, opts *VerifyOptions) ([]*VerificationResult, error) {
+	if len(responses) != len(factsPer) {
+		return nil, fmt.Errorf("verify batch: responses and factsPer length mismatch (%d != %d)", len(responses), len(factsPer))
+	}
+	opts = opts.withDefaults()
+
+	results := make([]*VerificationResult, len(responses))
+	verdictsPer := make([][]ClaimVerdict, len(responses))
+	matchesPer := make([][]EvidenceMatch, len(responses))
+
+	// pending maps a position in the global NLI batch back to its (unit, verdict).
+	type pending struct{ unit, vi int }
+	var premiseBatch, hypothesisBatch []string
+	var pend []pending
+
+	for u, response := range responses {
+		claims := SplitClaims(response)
+		if len(claims) == 0 {
+			results[u] = &VerificationResult{TrustScore: 1.0, Pass: true}
+			continue
+		}
+		matches, err := MatchEvidence(ctx, v.embedder, claims, factsPer[u])
+		if err != nil {
+			return nil, err
+		}
+		matchesPer[u] = matches
+
+		verdicts := make([]ClaimVerdict, len(matches))
+		for i, m := range matches {
+			verdicts[i] = ClaimVerdict{
+				Text:            m.Claim.Text,
+				Evidence:        m.BestEvidence,
+				EvidenceScore:   m.BestScore,
+				IsMetaStatement: m.Claim.IsMetaStatement,
+			}
+			switch {
+			case m.Claim.IsMetaStatement:
+				verdicts[i].Verdict = VerdictSkipped
+				verdicts[i].Confidence = 1.0
+			case m.BestScore < opts.GateThreshold:
+				verdicts[i].Verdict = VerdictUnverifiable
+				verdicts[i].Confidence = float32(1.0 - m.BestScore)
+			case v.nli == nil:
+				// Embedding-similarity fallback (identical to Verify's nil-NLI path).
+				if m.BestScore >= opts.SupportThreshold {
+					verdicts[i].Verdict = VerdictSupported
+					verdicts[i].Confidence = float32(m.BestScore)
+				} else {
+					verdicts[i].Verdict = VerdictUnverifiable
+					verdicts[i].Confidence = float32(1.0 - m.BestScore)
+				}
+			default:
+				premiseBatch = append(premiseBatch, m.BestEvidence)
+				hypothesisBatch = append(hypothesisBatch, m.Claim.Text)
+				pend = append(pend, pending{unit: u, vi: i})
+			}
+		}
+		verdictsPer[u] = verdicts
+	}
+
+	// Single NLI pass over every gated pair from all units.
+	if len(premiseBatch) > 0 && v.nli != nil {
+		nliResults, err := v.nli.ClassifyBatch(ctx, premiseBatch, hypothesisBatch)
+		if err != nil {
+			v.logger.Warn("NLI batch classification failed, marking claims unverifiable", "error", err)
+			for _, p := range pend {
+				verdictsPer[p.unit][p.vi].Verdict = VerdictUnverifiable
+			}
+		} else {
+			for k, p := range pend {
+				scores := nliResults[k]
+				verdictsPer[p.unit][p.vi].NLI = &scores
+				verdictsPer[p.unit][p.vi].Verdict, verdictsPer[p.unit][p.vi].Confidence =
+					classifyVerdict(matchesPer[p.unit][p.vi], scores, opts)
+			}
+		}
+	}
+
+	for u := range responses {
+		if results[u] != nil {
+			continue // empty-claims short-circuit set above
+		}
+		results[u] = aggregate(verdictsPer[u], opts)
+	}
+	return results, nil
 }
 
 // classifyVerdict determines the verdict for a claim based on NLI scores and evidence match.

--- a/pkg/verification/verifier_batch_test.go
+++ b/pkg/verification/verifier_batch_test.go
@@ -1,0 +1,160 @@
+package verification
+
+import (
+	"context"
+	"testing"
+)
+
+// hashEmbedder is a deterministic, dependency-free embedder: identical text always
+// maps to the same vector (so a fact equal to a claim scores cosine ~1.0), and the
+// mapping is stable across calls, which is all the equivalence test needs.
+type hashEmbedder struct{}
+
+func (hashEmbedder) Embed(_ context.Context, texts []string) ([][]float32, error) {
+	out := make([][]float32, len(texts))
+	for i, t := range texts {
+		v := make([]float32, 8)
+		for j := 0; j < len(t); j++ {
+			v[j%8] += float32(t[j])
+		}
+		out[i] = v
+	}
+	return out, nil
+}
+func (hashEmbedder) EmbedSingle(ctx context.Context, text string) ([]float32, error) {
+	v, err := hashEmbedder{}.Embed(ctx, []string{text})
+	if err != nil {
+		return nil, err
+	}
+	return v[0], nil
+}
+func (hashEmbedder) Dimensions() int { return 8 }
+func (hashEmbedder) Close() error    { return nil }
+
+// countingNLI returns a deterministic verdict (entailment when premise==hypothesis,
+// else neutral) and counts how many ClassifyBatch calls it receives, so the test
+// can assert VerifyBatch makes exactly one regardless of unit count.
+type countingNLI struct{ calls int }
+
+func (c *countingNLI) Classify(_ context.Context, premise, hypothesis string) (*NLIScores, error) {
+	c.calls++
+	return scoreFor(premise, hypothesis), nil
+}
+func (c *countingNLI) ClassifyBatch(_ context.Context, premises, hypotheses []string) ([]NLIScores, error) {
+	c.calls++
+	out := make([]NLIScores, len(premises))
+	for i := range premises {
+		out[i] = *scoreFor(premises[i], hypotheses[i])
+	}
+	return out, nil
+}
+func (c *countingNLI) Close() error { return nil }
+func scoreFor(premise, hypothesis string) *NLIScores {
+	if premise == hypothesis {
+		return &NLIScores{Entailment: 0.95, Neutral: 0.04, Contradiction: 0.01}
+	}
+	return &NLIScores{Entailment: 0.10, Neutral: 0.80, Contradiction: 0.10}
+}
+
+// TestVerifyBatchMatchesPerUnitVerify is the contract: VerifyBatch over N units must
+// produce, unit-for-unit, exactly what Verify produces on each unit alone — while
+// invoking the NLI model once instead of N times.
+func TestVerifyBatchMatchesPerUnitVerify(t *testing.T) {
+	responses := []string{
+		"Aspirin reduces fever in adults.",
+		"The patient has no documented allergies.",
+		"Metformin is first-line therapy for type 2 diabetes.",
+	}
+	factsPer := [][]string{
+		{"Aspirin reduces fever in adults.", "Aspirin is an analgesic."},
+		{"Penicillin allergy was recorded last year."},
+		{"Metformin is first-line therapy for type 2 diabetes."},
+	}
+
+	// Per-unit baseline (one ClassifyBatch call each).
+	perUnit := &countingNLI{}
+	vSingle := NewVerifier(hashEmbedder{}, perUnit, nil)
+	want := make([]*VerificationResult, len(responses))
+	for i := range responses {
+		r, err := vSingle.Verify(context.Background(), responses[i], factsPer[i], nil)
+		if err != nil {
+			t.Fatalf("Verify[%d]: %v", i, err)
+		}
+		want[i] = r
+	}
+
+	// Batched (one ClassifyBatch call total).
+	batched := &countingNLI{}
+	vBatch := NewVerifier(hashEmbedder{}, batched, nil)
+	got, err := vBatch.VerifyBatch(context.Background(), responses, factsPer, nil)
+	if err != nil {
+		t.Fatalf("VerifyBatch: %v", err)
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got %d results, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i].TrustScore != want[i].TrustScore {
+			t.Errorf("unit %d trust score: got %v want %v", i, got[i].TrustScore, want[i].TrustScore)
+		}
+		if got[i].Stats != want[i].Stats {
+			t.Errorf("unit %d stats: got %+v want %+v", i, got[i].Stats, want[i].Stats)
+		}
+		if len(got[i].Claims) != len(want[i].Claims) {
+			t.Fatalf("unit %d claim count: got %d want %d", i, len(got[i].Claims), len(want[i].Claims))
+		}
+		for j := range want[i].Claims {
+			if got[i].Claims[j].Verdict != want[i].Claims[j].Verdict {
+				t.Errorf("unit %d claim %d verdict: got %v want %v", i, j,
+					got[i].Claims[j].Verdict, want[i].Claims[j].Verdict)
+			}
+		}
+	}
+
+	// The whole point: one model invocation for the batch, vs one per unit.
+	if batched.calls != 1 {
+		t.Errorf("VerifyBatch made %d NLI calls, want 1", batched.calls)
+	}
+	if perUnit.calls != len(responses) {
+		t.Errorf("per-unit baseline made %d NLI calls, want %d", perUnit.calls, len(responses))
+	}
+}
+
+// TestVerifyBatchNilNLI confirms the embedding-only fallback (used on CPU-only
+// deployments where the NLI model is disabled) still matches per-unit Verify and
+// never touches a model.
+func TestVerifyBatchNilNLI(t *testing.T) {
+	responses := []string{"Aspirin reduces fever.", "Unrelated filler sentence here."}
+	factsPer := [][]string{
+		{"Aspirin reduces fever."},
+		{"A completely different topic about ships."},
+	}
+	v := NewVerifier(hashEmbedder{}, nil, nil)
+
+	want := make([]*VerificationResult, len(responses))
+	for i := range responses {
+		r, err := v.Verify(context.Background(), responses[i], factsPer[i], nil)
+		if err != nil {
+			t.Fatalf("Verify[%d]: %v", i, err)
+		}
+		want[i] = r
+	}
+	got, err := v.VerifyBatch(context.Background(), responses, factsPer, nil)
+	if err != nil {
+		t.Fatalf("VerifyBatch: %v", err)
+	}
+	for i := range want {
+		if got[i].TrustScore != want[i].TrustScore || got[i].Stats != want[i].Stats {
+			t.Errorf("unit %d: got trust=%v stats=%+v want trust=%v stats=%+v",
+				i, got[i].TrustScore, got[i].Stats, want[i].TrustScore, want[i].Stats)
+		}
+	}
+}
+
+// TestVerifyBatchLengthMismatch guards the input contract.
+func TestVerifyBatchLengthMismatch(t *testing.T) {
+	v := NewVerifier(hashEmbedder{}, nil, nil)
+	if _, err := v.VerifyBatch(context.Background(), []string{"a", "b"}, [][]string{{"x"}}, nil); err == nil {
+		t.Fatal("expected error on responses/factsPer length mismatch, got nil")
+	}
+}


### PR DESCRIPTION
## What

Adds `Verifier.VerifyBatch(ctx, responses, factsPer, opts)` — verifies N independent `(response, facts)` units in a single pass, issuing **one** NLI `ClassifyBatch` (and batched embedding) across every gated claim-evidence pair from all units, instead of one `Verify` call per unit.

## Why

`Verify` embeds a claim's evidence and runs NLI per call. Callers that verify many claims in a loop (the humn DDx knowledge-base recheck verifies up to 16 model-asserted claims) therefore pay **one embedder round-trip and one model forward pass per claim, serialized** — the dominant cost of that stage. On CPU that's tens of seconds; even with NLI disabled the per-claim embed round-trips add up.

`VerifyBatch` drops the model/embedder invocation count from N to ~1. Each unit's result is **unit-for-unit identical** to `Verify(unit)`; with a nil NLI client it uses the same embedding-similarity fallback per unit (so it also amortizes the embedder when NLI is disabled).

## Test

`verifier_batch_test.go` proves:
- per-unit equivalence with `Verify` (with and without an NLI client), and
- exactly **one** `ClassifyBatch` call for the whole batch vs N for the per-unit baseline.

Consumed by humn PR (DDx recheck batching).