### PR TITLE
serve-grpc: multi-graph router mode (predicato owns topic routing)

### DIFF
--- a/cmd/predicato/serve_grpc.go
+++ b/cmd/predicato/serve_grpc.go
@@ -59,6 +59,22 @@ func init() {
 	serveGRPCCmd.Flags().String("embedding-base-url", "", "Embedding base URL")
 
 	serveGRPCCmd.Flags().String("telemetry-parquet-path", "", "Path to directory for telemetry")
+
+	// Router-mode flags. When --source-dir is set, the server discovers topic
+	// graphs in that directory and routes/merges queries across them instead of
+	// serving a single graph.
+	serveGRPCCmd.Flags().String("source-dir", "", "Directory of topic graphs (<slug>.duckdb/.lbug + <slug>.md). When set, enables multi-graph router mode.")
+	serveGRPCCmd.Flags().String("strategy", "cross_encoder", "Routing strategy: cross_encoder, embedding, keyword, topic_based")
+	serveGRPCCmd.Flags().String("merge-strategy", "rrf", "Result merge strategy: rrf, simple_concat, max_score")
+	serveGRPCCmd.Flags().Int("max-graphs", 2, "Max number of topic graphs to query per request")
+	serveGRPCCmd.Flags().Float64("min-confidence", 0.3, "Minimum routing confidence to include a topic graph")
+	serveGRPCCmd.Flags().Int("max-open-graphs", 8, "Max number of topic graph databases kept open simultaneously (LRU eviction)")
+
+	// Reranker selection for cross_encoder routing. When empty, an
+	// embedding-based reranker is built from the shared embedder (no extra model).
+	serveGRPCCmd.Flags().String("reranker-provider", "", "Cross-encoder reranker provider for cross_encoder strategy: embedding (default), reranker, local, openai")
+	serveGRPCCmd.Flags().String("reranker-model", "", "Reranker model name (for reranker provider)")
+	serveGRPCCmd.Flags().String("reranker-base-url", "", "Reranker base URL (for Jina-compatible reranker provider)")
 }
 
 func runServeGRPC(cmd *cobra.Command, _ []string) error {
@@ -68,6 +84,13 @@ func runServeGRPC(cmd *cobra.Command, _ []string) error {
 	}
 	overrideConfigWithFlags(cmd, cfg)
 
+	// Multi-graph router mode: when --source-dir is set, discover topic graphs
+	// in that directory and route/merge queries across them.
+	if sourceDir, _ := cmd.Flags().GetString("source-dir"); sourceDir != "" {
+		return runServeGRPCRouterMode(cmd, cfg, sourceDir, grpcAddr)
+	}
+
+	// Single-graph mode (unchanged).
 	fmt.Println("Initializing Predicato...")
 	predicatoInstance, _, _, err := initializePredicato(cmd, cfg)
 	if err != nil {

--- a/cmd/predicato/serve_grpc_router.go
+++ b/cmd/predicato/serve_grpc_router.go
@@ -1,0 +1,154 @@
+//go:build cgo
+
+package predicato
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+
+	"github.com/soundprediction/predicato/pkg/config"
+	"github.com/soundprediction/predicato/pkg/crossencoder"
+	"github.com/soundprediction/predicato/pkg/embedder"
+	"github.com/soundprediction/predicato/pkg/grpcsvc"
+	predicatoLogger "github.com/soundprediction/predicato/pkg/logger"
+	"github.com/soundprediction/predicato/pkg/router"
+	"github.com/spf13/cobra"
+)
+
+// runServeGRPCRouterMode wires the existing multi-graph router engine
+// (pkg/router) into the gRPC server: it discovers topic graphs under sourceDir,
+// builds a shared embedder + NLP client (reusing the same helpers as the
+// single-graph path, so no throwaway graph is opened), optionally builds a
+// cross-encoder reranker, constructs the Manager/classifier/Router, and serves
+// a RouterPredicato adapter that routes Search across topic graphs.
+func runServeGRPCRouterMode(cmd *cobra.Command, cfg *config.Config, sourceDir, addr string) error {
+	logger := slog.New(predicatoLogger.NewColorHandler(os.Stderr, &slog.HandlerOptions{
+		Level: slog.LevelInfo,
+	}))
+
+	strategy, _ := cmd.Flags().GetString("strategy")
+	mergeStrategy, _ := cmd.Flags().GetString("merge-strategy")
+	maxGraphs, _ := cmd.Flags().GetInt("max-graphs")
+	minConfidence, _ := cmd.Flags().GetFloat64("min-confidence")
+	maxOpenGraphs, _ := cmd.Flags().GetInt("max-open-graphs")
+
+	routerCfg := router.RouterConfig{
+		Strategy:      strategy,
+		MergeStrategy: mergeStrategy,
+		MinConfidence: minConfidence,
+		MaxGraphs:     maxGraphs,
+	}
+
+	// Discover topic graphs and their routing descriptors.
+	fmt.Printf("Discovering topic graphs in %s...\n", sourceDir)
+	configs, routingTexts, err := router.DiscoverTopicGraphs(sourceDir)
+	if err != nil {
+		return fmt.Errorf("failed to discover topic graphs: %w", err)
+	}
+	if len(configs) == 0 {
+		return fmt.Errorf("no topic graphs discovered in %s (expected <slug>.md paired with <slug>.duckdb/.lbug/.ladybug)", sourceDir)
+	}
+
+	// Build shared embedder + NLP client without opening a throwaway graph.
+	fmt.Println("Initializing embedder...")
+	embedderClient, err := buildEmbedder(cfg)
+	if err != nil {
+		return fmt.Errorf("failed to build embedder: %w", err)
+	}
+	nlpClient, err := buildNLP(cmd, cfg, &logger)
+	if err != nil {
+		return fmt.Errorf("failed to build NLP client: %w", err)
+	}
+
+	// Build a cross-encoder reranker when the cross_encoder strategy is selected.
+	var reranker crossencoder.Client
+	if routerCfg.GetStrategyOrDefault() == "cross_encoder" {
+		reranker, err = buildReranker(cmd, embedderClient)
+		if err != nil {
+			return fmt.Errorf("failed to build reranker: %w", err)
+		}
+	}
+
+	// Wire the router engine.
+	mgr := router.NewManagerWithOptions(configs, nlpClient, embedderClient, logger, maxOpenGraphs)
+	if reranker != nil {
+		mgr.SetCrossEncoder(reranker)
+	}
+
+	classifier, err := router.NewTopicClassifier(configs, routerCfg, embedderClient, reranker, routingTexts)
+	if err != nil {
+		return fmt.Errorf("failed to build topic classifier: %w", err)
+	}
+
+	r := router.NewRouter(mgr, classifier, routerCfg, logger)
+
+	def, err := mgr.GetDefaultClient()
+	if err != nil {
+		return fmt.Errorf("failed to get default client: %w", err)
+	}
+
+	adapter := router.NewRouterPredicato(r, def)
+
+	// Startup banner.
+	fmt.Printf("\nPredicato gRPC server (ROUTER MODE)\n")
+	fmt.Printf("  topics:         %d\n", len(configs))
+	fmt.Printf("  strategy:       %s\n", routerCfg.GetStrategyOrDefault())
+	fmt.Printf("  merge:          %s\n", routerCfg.GetMergeStrategyOrDefault())
+	fmt.Printf("  max-graphs:     %d\n", routerCfg.GetMaxGraphsOrDefault())
+	fmt.Printf("  min-confidence: %.2f\n", routerCfg.GetMinConfidenceOrDefault())
+	fmt.Printf("  max-open:       %d\n", maxOpenGraphs)
+	for _, c := range configs {
+		marker := ""
+		if c.Default {
+			marker = " (default)"
+		}
+		if c.Fallback {
+			marker += " (fallback)"
+		}
+		fmt.Printf("    - %s%s\n", c.Name, marker)
+	}
+	fmt.Printf("Listening on %s (service %s)\n\n", addr, grpcsvc.ServiceName)
+
+	// Ensure clients are closed on shutdown of Serve (best-effort).
+	defer func() {
+		if cerr := r.Close(context.Background()); cerr != nil {
+			logger.Warn("error closing router", "error", cerr)
+		}
+	}()
+
+	return grpcsvc.Serve(adapter, addr)
+}
+
+// buildReranker builds a cross-encoder reranker Client for cross_encoder
+// routing. When --reranker-provider is empty it defaults to an embedding-based
+// reranker that reuses the shared embedder (no extra model loaded).
+func buildReranker(cmd *cobra.Command, embedderClient embedder.Client) (crossencoder.Client, error) {
+	provider, _ := cmd.Flags().GetString("reranker-provider")
+	model, _ := cmd.Flags().GetString("reranker-model")
+	baseURL, _ := cmd.Flags().GetString("reranker-base-url")
+
+	switch provider {
+	case "", "embedding", "candle":
+		if embedderClient == nil {
+			return nil, fmt.Errorf("embedding reranker requires an embedder; none available")
+		}
+		fmt.Println("Reranker: embedding-based (reuses shared embedder)")
+		return crossencoder.NewEmbeddingRerankerClient(embedderClient, crossencoder.EmbeddingConfig{}), nil
+
+	case "reranker":
+		fmt.Printf("Reranker: Jina-compatible API (%s)\n", baseURL)
+		return crossencoder.NewRerankerClient(crossencoder.RerankerConfig{
+			BaseURL: baseURL,
+			Config:  crossencoder.Config{Model: model},
+		}), nil
+
+	case "local":
+		fmt.Println("Reranker: local text-similarity")
+		return crossencoder.NewLocalRerankerClient(crossencoder.Config{}), nil
+
+	default:
+		return nil, fmt.Errorf("unsupported reranker provider: %s (supported: embedding, reranker, local)", provider)
+	}
+}

--- a/cmd/predicato/serve_grpc_router_stub.go
+++ b/cmd/predicato/serve_grpc_router_stub.go
@@ -1,0 +1,16 @@
+//go:build !cgo
+
+package predicato
+
+import (
+	"fmt"
+
+	"github.com/soundprediction/predicato/pkg/config"
+	"github.com/spf13/cobra"
+)
+
+// runServeGRPCRouterMode is unavailable without CGO, since the multi-graph
+// router engine (pkg/router) and graph drivers require CGO.
+func runServeGRPCRouterMode(_ *cobra.Command, _ *config.Config, _, _ string) error {
+	return fmt.Errorf("router mode (--source-dir) requires a CGO build of predicato")
+}

--- a/cmd/predicato/server.go
+++ b/cmd/predicato/server.go
@@ -303,136 +303,16 @@ func initializePredicato(cmd *cobra.Command, cfg *config.Config) (predicato.Pred
 	}
 
 	// Initialize NLP client
-	var nlProcessor nlp.Client
-
-	if useGLiNER2 {
-		endpoint, _ := cmd.Flags().GetString("gliner2-endpoint")
-
-		// Check if server is running, if not start it
-		if err := ensureGLiNER2Server(endpoint); err != nil {
-			return nil, nil, nil, fmt.Errorf("failed to ensure GLiNER2 server: %w", err)
-		}
-
-		glinerClient, err := gliner2.NewClient(gliner2.Config{
-			Provider: gliner2.ProviderLocal,
-			Local: &gliner2.LocalConfig{
-				Endpoint: endpoint,
-			},
-		})
-		if err != nil {
-			return nil, nil, nil, fmt.Errorf("failed to create GLiNER2 client: %w", err)
-		}
-
-		nlProcessor = glinerClient
-		fmt.Printf("Using GLiNER2 NLP provider at: %s (Verified Healthy)\n", endpoint)
-
-		// Update config to reflect GLiNER2 usage so logging and other components are aware
-		defaultModel := cfg.NLP.Models["default"]
-		defaultModel.Provider = "gliner2"
-		defaultModel.Model = "gliner2-multi-v1" // or prompt for model?
-		cfg.NLP.Models["default"] = defaultModel
+	nlProcessor, err := buildNLP(cmd, cfg, &logger)
+	if err != nil {
+		return nil, nil, nil, err
 	}
-
 	defaultModel := cfg.NLP.Models["default"]
-	if nlProcessor == nil && defaultModel.APIKey != "" {
-		switch defaultModel.Provider {
-		case "openai":
-			nlpConfig := nlp.Config{
-				Model:       defaultModel.Model,
-				Temperature: &defaultModel.Temperature,
-				BaseURL:     defaultModel.BaseURL,
-			}
-			baseNLPClient, err := nlp.NewOpenAIClient(defaultModel.APIKey, nlpConfig)
-			if err != nil {
-				return nil, nil, nil, fmt.Errorf("failed to create NLP client: %w", err)
-			}
-			// Wrap with retry client for automatic retry on errors
-			retryClient, err := nlp.NewRetryClient(baseNLPClient, nlp.DefaultRetryConfig())
-			if err != nil {
-				return nil, nil, nil, fmt.Errorf("failed to create retry client: %w", err)
-			}
-
-			// Telemetry using Parquet
-			trackingPath := cfg.Telemetry.ParquetPath
-			if trackingPath == "" {
-				homeDir, err := os.UserHomeDir()
-				if err != nil {
-					return nil, nil, nil, fmt.Errorf("failed to get user home directory: %w", err)
-				}
-				trackingPath = fmt.Sprintf("%s/.predicato/telemetry", homeDir)
-			}
-
-			// Ensure directory exists
-			if err := os.MkdirAll(trackingPath, 0755); err != nil {
-				return nil, nil, nil, fmt.Errorf("failed to create telemetry directory: %w", err)
-			}
-
-			// Initialize Token Tracker
-			tracker, err := nlp.NewTokenTracker(trackingPath)
-			if err != nil {
-				fmt.Printf("Warning: Failed to initialize token tracker: %v\n", err)
-				nlProcessor = retryClient
-			} else {
-				nlProcessor = nlp.NewTokenTrackingClient(retryClient, tracker)
-				fmt.Printf("Token tracking enabled at: %s\n", trackingPath)
-			}
-
-			// Initialize Error Tracking Logger
-			colorHandler := predicatoLogger.NewColorHandler(os.Stderr, &slog.HandlerOptions{
-				Level: slog.LevelInfo,
-			})
-
-			parquetHandler, err := telemetry.NewParquetHandler(colorHandler, trackingPath)
-			if err != nil {
-				fmt.Printf("Warning: Failed to initialize error tracking: %v\n", err)
-			} else {
-				// Update the global logger to use our new handler
-				logger = slog.New(parquetHandler)
-				fmt.Printf("Error tracking enabled\n")
-			}
-		default:
-			return nil, nil, nil, fmt.Errorf("unsupported NLP provider: %s", defaultModel.Provider)
-		}
-	} else if nlProcessor == nil {
-		// Default to internal Candle NLP client (no external API required)
-		fmt.Println("Initializing internal Candle NLP service...")
-		candleClient := candleAdapter.NewClient(candleAdapter.CandleNLPConfig{
-			TextGenModelID: "HuggingFaceTB/SmolLM2-360M-Instruct",
-		})
-		nlProcessor = candleAdapter.NewLLMAdapter(candleClient, "text_generation")
-		fmt.Println("Candle NLP service initialized (internal, no API key required)")
-	}
 
 	// Initialize embedder client
-	var embedderClient embedder.Client
-	if cfg.Embedding.APIKey != "" {
-		switch cfg.Embedding.Provider {
-		case "openai":
-			embedderConfig := embedder.Config{
-				Model:   cfg.Embedding.Model,
-				BaseURL: cfg.Embedding.BaseURL,
-			}
-			embedderClient = embedder.NewOpenAIEmbedder(cfg.Embedding.APIKey, embedderConfig)
-		default:
-			return nil, nil, nil, fmt.Errorf("unsupported embedding provider: %s", cfg.Embedding.Provider)
-		}
-	} else {
-		// Default to internal Candle embedder (no external API required)
-		fmt.Println("Initializing internal Candle embedder service...")
-		internalEmbedder, err := candleAdapter.NewCandleEmbedderClient(&candleAdapter.CandleEmbedderConfig{
-			Model:      "qwen/qwen3-embedding-0.6b",
-			Dimensions: 1024,
-			Normalize:  true,
-		})
-		if err != nil {
-			fmt.Printf("Warning: Failed to initialize Candle embedder: %v\n", err)
-			fmt.Println("Continuing without embedder - semantic search will be unavailable")
-		} else {
-			embedderClient = internalEmbedder
-			cfg.Embedding.Provider = "candle"
-			cfg.Embedding.Model = "qwen/qwen3-embedding-0.6b"
-			fmt.Println("Candle embedder initialized (internal, no API key required)")
-		}
+	embedderClient, err := buildEmbedder(cfg)
+	if err != nil {
+		return nil, nil, nil, err
 	}
 
 	// Initialize FactStore (PostgreSQL with VectorChord required)
@@ -478,6 +358,155 @@ func initializePredicato(cmd *cobra.Command, cfg *config.Config) (predicato.Pred
 	}
 
 	return client, embedderClient, nlProcessor, nil
+}
+
+// buildNLP constructs the NLP client from config and flags. It mirrors the
+// behaviour previously inlined in initializePredicato so that other commands
+// (e.g. serve-grpc router mode) can obtain an NLP client without opening a
+// throwaway graph. The logger pointer may be replaced with a telemetry-aware
+// logger when error tracking is enabled.
+func buildNLP(cmd *cobra.Command, cfg *config.Config, logger **slog.Logger) (nlp.Client, error) {
+	var nlProcessor nlp.Client
+
+	if useGLiNER2 {
+		endpoint, _ := cmd.Flags().GetString("gliner2-endpoint")
+
+		// Check if server is running, if not start it
+		if err := ensureGLiNER2Server(endpoint); err != nil {
+			return nil, fmt.Errorf("failed to ensure GLiNER2 server: %w", err)
+		}
+
+		glinerClient, err := gliner2.NewClient(gliner2.Config{
+			Provider: gliner2.ProviderLocal,
+			Local: &gliner2.LocalConfig{
+				Endpoint: endpoint,
+			},
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to create GLiNER2 client: %w", err)
+		}
+
+		nlProcessor = glinerClient
+		fmt.Printf("Using GLiNER2 NLP provider at: %s (Verified Healthy)\n", endpoint)
+
+		// Update config to reflect GLiNER2 usage so logging and other components are aware
+		defaultModel := cfg.NLP.Models["default"]
+		defaultModel.Provider = "gliner2"
+		defaultModel.Model = "gliner2-multi-v1" // or prompt for model?
+		cfg.NLP.Models["default"] = defaultModel
+	}
+
+	defaultModel := cfg.NLP.Models["default"]
+	if nlProcessor == nil && defaultModel.APIKey != "" {
+		switch defaultModel.Provider {
+		case "openai":
+			nlpConfig := nlp.Config{
+				Model:       defaultModel.Model,
+				Temperature: &defaultModel.Temperature,
+				BaseURL:     defaultModel.BaseURL,
+			}
+			baseNLPClient, err := nlp.NewOpenAIClient(defaultModel.APIKey, nlpConfig)
+			if err != nil {
+				return nil, fmt.Errorf("failed to create NLP client: %w", err)
+			}
+			// Wrap with retry client for automatic retry on errors
+			retryClient, err := nlp.NewRetryClient(baseNLPClient, nlp.DefaultRetryConfig())
+			if err != nil {
+				return nil, fmt.Errorf("failed to create retry client: %w", err)
+			}
+
+			// Telemetry using Parquet
+			trackingPath := cfg.Telemetry.ParquetPath
+			if trackingPath == "" {
+				homeDir, err := os.UserHomeDir()
+				if err != nil {
+					return nil, fmt.Errorf("failed to get user home directory: %w", err)
+				}
+				trackingPath = fmt.Sprintf("%s/.predicato/telemetry", homeDir)
+			}
+
+			// Ensure directory exists
+			if err := os.MkdirAll(trackingPath, 0755); err != nil {
+				return nil, fmt.Errorf("failed to create telemetry directory: %w", err)
+			}
+
+			// Initialize Token Tracker
+			tracker, err := nlp.NewTokenTracker(trackingPath)
+			if err != nil {
+				fmt.Printf("Warning: Failed to initialize token tracker: %v\n", err)
+				nlProcessor = retryClient
+			} else {
+				nlProcessor = nlp.NewTokenTrackingClient(retryClient, tracker)
+				fmt.Printf("Token tracking enabled at: %s\n", trackingPath)
+			}
+
+			// Initialize Error Tracking Logger
+			colorHandler := predicatoLogger.NewColorHandler(os.Stderr, &slog.HandlerOptions{
+				Level: slog.LevelInfo,
+			})
+
+			parquetHandler, err := telemetry.NewParquetHandler(colorHandler, trackingPath)
+			if err != nil {
+				fmt.Printf("Warning: Failed to initialize error tracking: %v\n", err)
+			} else if logger != nil {
+				// Update the global logger to use our new handler
+				*logger = slog.New(parquetHandler)
+				fmt.Printf("Error tracking enabled\n")
+			}
+		default:
+			return nil, fmt.Errorf("unsupported NLP provider: %s", defaultModel.Provider)
+		}
+	} else if nlProcessor == nil {
+		// Default to internal Candle NLP client (no external API required)
+		fmt.Println("Initializing internal Candle NLP service...")
+		candleClient := candleAdapter.NewClient(candleAdapter.CandleNLPConfig{
+			TextGenModelID: "HuggingFaceTB/SmolLM2-360M-Instruct",
+		})
+		nlProcessor = candleAdapter.NewLLMAdapter(candleClient, "text_generation")
+		fmt.Println("Candle NLP service initialized (internal, no API key required)")
+	}
+
+	return nlProcessor, nil
+}
+
+// buildEmbedder constructs the embedder client from config. It mirrors the
+// behaviour previously inlined in initializePredicato so that other commands
+// (e.g. serve-grpc router mode) can obtain a shared embedder without opening a
+// throwaway graph. cfg.Embedding.Provider/Model may be updated to reflect the
+// fallback Candle embedder.
+func buildEmbedder(cfg *config.Config) (embedder.Client, error) {
+	var embedderClient embedder.Client
+	if cfg.Embedding.APIKey != "" {
+		switch cfg.Embedding.Provider {
+		case "openai":
+			embedderConfig := embedder.Config{
+				Model:   cfg.Embedding.Model,
+				BaseURL: cfg.Embedding.BaseURL,
+			}
+			embedderClient = embedder.NewOpenAIEmbedder(cfg.Embedding.APIKey, embedderConfig)
+		default:
+			return nil, fmt.Errorf("unsupported embedding provider: %s", cfg.Embedding.Provider)
+		}
+	} else {
+		// Default to internal Candle embedder (no external API required)
+		fmt.Println("Initializing internal Candle embedder service...")
+		internalEmbedder, err := candleAdapter.NewCandleEmbedderClient(&candleAdapter.CandleEmbedderConfig{
+			Model:      "qwen/qwen3-embedding-0.6b",
+			Dimensions: 1024,
+			Normalize:  true,
+		})
+		if err != nil {
+			fmt.Printf("Warning: Failed to initialize Candle embedder: %v\n", err)
+			fmt.Println("Continuing without embedder - semantic search will be unavailable")
+		} else {
+			embedderClient = internalEmbedder
+			cfg.Embedding.Provider = "candle"
+			cfg.Embedding.Model = "qwen/qwen3-embedding-0.6b"
+			fmt.Println("Candle embedder initialized (internal, no API key required)")
+		}
+	}
+
+	return embedderClient, nil
 }
 
 func ensureGLiNER2Server(endpoint string) error {

--- a/pkg/router/predicato_adapter.go
+++ b/pkg/router/predicato_adapter.go
@@ -1,0 +1,60 @@
+//go:build cgo
+
+package router
+
+import (
+	"context"
+
+	predicato "github.com/soundprediction/predicato"
+	"github.com/soundprediction/predicato/pkg/types"
+)
+
+// RouterPredicato adapts a multi-graph Router to the predicato.Predicato
+// interface so it can be served by the standard gRPC server (pkg/grpcsvc).
+//
+// It embeds a default predicato.Predicato (the router's default client) so that
+// all interface methods are satisfied automatically; only Search is overridden
+// to route the query across topic graphs and merge the results.
+type RouterPredicato struct {
+	predicato.Predicato // default client: provides all non-Search methods
+	r                   *Router
+}
+
+// NewRouterPredicato wraps a Router and a default predicato.Predicato.
+// The default client backs every method except Search (which the router
+// fans out across the matched topic graphs and merges).
+func NewRouterPredicato(r *Router, def predicato.Predicato) *RouterPredicato {
+	return &RouterPredicato{
+		Predicato: def,
+		r:         r,
+	}
+}
+
+// Search routes the query across the topic graphs and merges the results into a
+// single types.SearchResults. Per-node graph provenance (GroupID) is preserved;
+// when a merged node has an empty GroupID it is backfilled from the merger's
+// per-node Sources map so downstream consumers keep graph provenance.
+func (a *RouterPredicato) Search(ctx context.Context, query string, cfg *types.SearchConfig) (*types.SearchResults, error) {
+	m, err := a.r.Search(ctx, query, cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	// Backfill node provenance from Sources when GroupID is empty so that
+	// downstream consumers can still tell which topic graph a node came from.
+	for _, n := range m.Nodes {
+		if n == nil || n.GroupID != "" {
+			continue
+		}
+		if srcs, ok := m.Sources[n.Uuid]; ok && len(srcs) > 0 {
+			n.GroupID = srcs[0]
+		}
+	}
+
+	return &types.SearchResults{
+		Query: query,
+		Nodes: m.Nodes,
+		Edges: m.Edges,
+		Total: m.Total,
+	}, nil
+}


### PR DESCRIPTION
## What
Adds a **router mode** to `predicato serve-grpc` so a single predicato gRPC server manages the multi-graph topic router internally (discovery → classify → fan-out to top-K topic graphs → RRF merge), instead of serving one graph. This lets predicato run as its own process while preserving the topic-routing behavior the client previously did in-process — the client just dials one endpoint.

The router *engine* already existed in `pkg/router` (Manager/classifiers/merger/discovery); this wires it into the gRPC path.

## Changes
- `pkg/router/predicato_adapter.go` (new): `RouterPredicato` embeds the default-client `predicato.Predicato` (supplies all ~22 interface methods) and overrides only `Search` → `Router.Search` → `types.SearchResults`. Backfills empty `node.GroupID` from the merger's per-node `Sources` so graph provenance survives.
- `cmd/predicato/serve_grpc.go` + `serve_grpc_router.go` (new): when `--source-dir` is set, build the router (discover → embedder/nlp → optional reranker → `NewManagerWithOptions` → `NewTopicClassifier` → `NewRouter` → `GetDefaultClient` → adapter → `grpcsvc.Serve`); else the single-graph path is unchanged. Flags: `--source-dir --strategy --merge-strategy --max-graphs --min-confidence --max-open-graphs`.
- `cmd/predicato/server.go`: extracted `buildEmbedder`/`buildNLP` helpers (behavior preserved) so router mode reuses them without opening a throwaway graph.

## Configured by the client
Routing is driven by the directory's `.md`/`.yaml` descriptors + the strategy/merge/max-graphs flags — i.e. the client (humn) owns the topic-graph dir and router settings; predicato just applies them.

## Validated live (EC2)
Standalone `predicato.service` (router mode, 31 topic graphs over `/data/topic-graphs/ladybug`, `:50072`, embedder→`humn-embed:9099`). Repointed humn's `[predicato] grpc_endpoint` at it. DDx evidence parity vs the prior in-process router: **102 (92 from KG) vs 103 (93)**, same lead diagnosis — routing/merge identical, now server-side. LRU-bounded memory (6.5GB / `max-open-graphs=6`), no errors.

Note: branched on top of #265 (verify-batch); base is that branch for a clean diff.