### PR TITLE
grpcsvc: optional x-api-key auth (fail-open, Health exempt)

### DIFF
--- a/pkg/grpcsvc/apikey.go
+++ b/pkg/grpcsvc/apikey.go
@@ -1,0 +1,68 @@
+package grpcsvc
+
+import (
+	"context"
+	"crypto/subtle"
+	"strings"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+)
+
+// apiKeyFromContext extracts the presented API key from the incoming metadata,
+// preferring the "x-api-key" header and falling back to a bearer token in the
+// "authorization" header.
+func apiKeyFromContext(ctx context.Context) string {
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return ""
+	}
+	if vals := md.Get("x-api-key"); len(vals) > 0 {
+		return vals[0]
+	}
+	if vals := md.Get("authorization"); len(vals) > 0 {
+		return strings.TrimSpace(strings.TrimPrefix(vals[0], "Bearer "))
+	}
+	return ""
+}
+
+// authorize returns nil when the request is allowed and an Unauthenticated error
+// otherwise. It is a no-op (always allows) when key is empty, enabling a
+// fail-open rollout. Health checks are always exempt.
+func authorize(ctx context.Context, fullMethod, key string) error {
+	if key == "" {
+		return nil
+	}
+	if strings.HasSuffix(fullMethod, "/Health") {
+		return nil
+	}
+	got := apiKeyFromContext(ctx)
+	if subtle.ConstantTimeCompare([]byte(got), []byte(key)) == 1 {
+		return nil
+	}
+	return status.Error(codes.Unauthenticated, "missing or invalid api key")
+}
+
+// APIKeyUnaryInterceptor enforces an x-api-key (or "authorization: Bearer <key>")
+// metadata header via constant-time compare. No-op when key=="" ; Health is exempt.
+func APIKeyUnaryInterceptor(key string) grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+		if err := authorize(ctx, info.FullMethod, key); err != nil {
+			return nil, err
+		}
+		return handler(ctx, req)
+	}
+}
+
+// APIKeyStreamInterceptor enforces an x-api-key (or "authorization: Bearer <key>")
+// metadata header via constant-time compare. No-op when key=="" ; Health is exempt.
+func APIKeyStreamInterceptor(key string) grpc.StreamServerInterceptor {
+	return func(srv any, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		if err := authorize(ss.Context(), info.FullMethod, key); err != nil {
+			return err
+		}
+		return handler(srv, ss)
+	}
+}

--- a/pkg/grpcsvc/server.go
+++ b/pkg/grpcsvc/server.go
@@ -3,7 +3,9 @@ package grpcsvc
 import (
 	"context"
 	"fmt"
+	"log"
 	"net"
+	"os"
 
 	"github.com/soundprediction/predicato"
 	"github.com/soundprediction/predicato/pkg/driver"
@@ -100,6 +102,15 @@ func Serve(p predicato.Predicato, addr string, opts ...grpc.ServerOption) error 
 	lis, err := net.Listen("tcp", addr)
 	if err != nil {
 		return fmt.Errorf("grpcsvc listen %s: %w", addr, err)
+	}
+	if key := os.Getenv("PREDICATO_API_KEY"); key != "" {
+		log.Printf("grpcsvc: api-key auth ON (x-api-key required; Health exempt)")
+		opts = append([]grpc.ServerOption{
+			grpc.ChainUnaryInterceptor(APIKeyUnaryInterceptor(key)),
+			grpc.ChainStreamInterceptor(APIKeyStreamInterceptor(key)),
+		}, opts...)
+	} else {
+		log.Printf("grpcsvc: api-key auth OFF (PREDICATO_API_KEY unset; fail-open)")
 	}
 	gs := grpc.NewServer(opts...)
 	NewServer(p).Register(gs)


### PR DESCRIPTION
Adds APIKeyUnaryInterceptor/APIKeyStreamInterceptor (constant-time compare of x-api-key / authorization Bearer; Health exempt; no-op when key empty). grpcsvc.Serve auto-applies them when PREDICATO_API_KEY is set — covers single-graph AND router mode. Deployed live (predicato.service, PREDICATO_API_KEY env); humn supplies the key; DDx routing validated. Stacks on #266.