### PR TITLE
Add Dockerfile + GHCR publish workflow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+# Keep the Docker build context small and the build reproducible. The image only
+# needs the Go module source + cmd/vendor-libs (extracted at build time). Exclude
+# local cruft and things the build never uses.
+.git
+bin/
+python/
+examples/
+docs/
+openspec/
+ralphy-spec/
+**/*.test
+**/*.out

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,61 @@
+name: docker-publish
+
+# Build the predicato image on every push/PR (validation) and publish it to
+# ghcr.io/soundprediction/predicato on pushes to main and version tags.
+#
+# Uses the repo-scoped GITHUB_TOKEN (packages: write) — no extra secrets. The
+# GHCR package is created private on first publish; make it public (or grant the
+# consuming machines read:packages) so nodes can `docker pull` it. The humn
+# pool-node compose can then set PREDICATO_IMAGE=ghcr.io/soundprediction/predicato:latest.
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: docker-publish-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Image metadata (tags + labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=sha
+            type=ref,event=tag
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,64 @@
+# Predicato knowledge-graph gRPC server.
+#
+# Self-contained: predicato vendors its Ladybug native lib under cmd/vendor-libs/
+# (extracted by cmd/extract-vendor-libs.sh at build time), so this image builds
+# from the repo alone — no external lib fetch, no sibling checkouts.
+#
+#   docker build -t predicato .
+#   docker run --rm predicato serve-grpc --addr 0.0.0.0:50072 --db-driver ladybug
+#
+# Published by .github/workflows/docker-publish.yml to
+# ghcr.io/soundprediction/predicato.
+
+# ---- build stage ---------------------------------------------------------
+FROM golang:1.26-bookworm AS build
+
+WORKDIR /src
+
+# Dependency layer first for caching.
+COPY go.mod go.sum ./
+RUN go mod download
+
+# Full source.
+COPY . .
+
+# Extract the vendored Ladybug native lib (liblbug.so + lbug.h [+ extensions])
+# for this platform into cmd/lib-ladybug/. Mirrors `make generate`.
+RUN bash cmd/extract-vendor-libs.sh
+
+# Build the CLI with CGO + the system_ladybug tag (mirrors the Makefile's
+# build-cli target), pointing the runtime rpath at the image's lib dir.
+ENV CGO_ENABLED=1
+RUN CGO_CFLAGS="-I$(pwd)/cmd/lib-ladybug" \
+    CGO_LDFLAGS="-L$(pwd)/cmd/lib-ladybug -Wl,-rpath,/opt/predicato/lib" \
+    go build -tags system_ladybug -o /out/predicato ./cmd/main.go
+
+# Collect the runtime native libs (liblbug.so, its .so.0 SONAME symlink, and any
+# bundled ladybug extensions).
+RUN mkdir -p /out/lib \
+    && cp -a cmd/lib-ladybug/liblbug.so* /out/lib/ \
+    && if [ -d cmd/lib-ladybug/extensions ]; then cp -a cmd/lib-ladybug/extensions /out/lib/extensions; fi
+
+# ---- runtime stage -------------------------------------------------------
+# trixie (GLIBC 2.40): predicato embeds a go-candle libcandle_binding.so it
+# dlopens at startup which needs GLIBC >= 2.39; bookworm (2.36) makes it log a
+# "GLIBC_2.39 not found" warning on every start. liblbug.so is the "compat"
+# build and runs fine on the newer glibc.
+FROM debian:trixie-slim
+
+# liblbug.so is a C++ shared library → needs libstdc++ and libgomp at runtime.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        libstdc++6 \
+        libgomp1 \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=build /out/predicato /usr/local/bin/predicato
+COPY --from=build /out/lib/ /opt/predicato/lib/
+
+ENV LD_LIBRARY_PATH=/opt/predicato/lib
+
+EXPOSE 50072
+
+ENTRYPOINT ["predicato"]
+CMD ["serve-grpc", "--addr", "0.0.0.0:50072", "--db-driver", "ladybug"]


### PR DESCRIPTION
## What

Make the predicato repo build and publish its own container image, so
`ghcr.io/soundprediction/predicato:latest` actually exists (the humn pool-node
compose expected it but it was never published).

- **`Dockerfile`** — multi-stage. Extracts predicato's in-repo vendored Ladybug
  lib (`cmd/extract-vendor-libs.sh`), CGO-builds `./cmd/main.go` with `-tags
  system_ladybug`, runs `serve-grpc` on `debian:trixie-slim`. Self-contained
  (predicato already vendors `liblbug.so`), so no external fetch or sibling
  checkouts needed.
- **`.dockerignore`** — trims the context (drops `python/`, `bin/`, `examples/`,
  `docs/`).
- **`.github/workflows/docker-publish.yml`** — builds on every PR (validation,
  no push) and pushes `latest` + a `sha-` tag on pushes to `main`, using the
  repo-scoped `GITHUB_TOKEN` (no extra secrets).

`trixie` (GLIBC 2.40) is the runtime base because predicato dlopens an embedded
go-candle lib that needs GLIBC ≥ 2.39 (bookworm logged a scary warning).

## Tested

Built and smoke-tested with **podman** on linux/amd64: `serve-grpc --help` shows
all `--reranker-*`/`--embedding-*` flags; a real `serve-grpc` run opens
LadybugDB and initializes the Candle NLP service; image ~234 MB.

## After merge (one-time)

The GHCR package is created **private** on first publish — flip it to public (or
grant the pool/API nodes `read:packages`) so `docker pull` works. Then the humn
pool-node compose can set `PREDICATO_IMAGE=ghcr.io/soundprediction/predicato:latest`
instead of building from source.