### PR TITLE
driver: connection pool for read-only graphs so concurrent reads overlap

### DIFF
--- a/pkg/driver/ladybug.go
+++ b/pkg/driver/ladybug.go
@@ -148,6 +148,16 @@ type LadybugDriver struct {
 	db     *ladybug.Database
 	client *ladybug.Connection // Note: Python uses AsyncConnection, but Go ladybug doesn't have async
 
+	// readPool holds additional connections used ONLY by read-only drivers, so
+	// concurrent reads against one graph run in parallel instead of serialising on
+	// k.mu. A single ladybug Connection is not thread-safe — hence the mutex — but
+	// the Database supports many independent Connections, which is how a read pool
+	// is safe here. Without it, callers that fan out over a graph (topic grounding,
+	// the recheck) collapse to one query at a time no matter how wide they fan.
+	// nil for read-write drivers, which keep the original single-connection path.
+	readPool  chan *ladybug.Connection
+	readConns []*ladybug.Connection
+
 	// Write queue for transparent concurrency handling
 	writeQueue   chan writeOperation
 	closeCh      chan struct{}
@@ -274,6 +284,11 @@ type LadybugDriverConfig struct {
 
 	// Maximum concurrent queries (defaults to 1)
 	MaxConcurrentQueries int
+
+	// ReadPoolSize is how many connections a READ-ONLY driver opens for concurrent
+	// reads. 0/1 keeps the historical single-connection behaviour. Ignored for
+	// read-write drivers, whose writes are already serialised through writeQueue.
+	ReadPoolSize int
 
 	// Write queue buffer size (defaults to 1000)
 	// Higher values allow more write operations to be queued before blocking
@@ -519,6 +534,35 @@ func NewLadybugDriverWithConfig(config *LadybugDriverConfig) (*LadybugDriver, er
 	}
 	driver.client = client
 
+	// Read-only graphs are queried concurrently (topic grounding, recheck, and the
+	// router's own fan-out), and one connection behind a mutex serialises all of
+	// it. Open a small pool so those reads actually overlap. Best-effort: if an
+	// extra connection cannot be opened we simply run with fewer, and with none we
+	// fall back to the original single-client path.
+	if config.ReadOnly && config.ReadPoolSize > 1 {
+		pool := make(chan *ladybug.Connection, config.ReadPoolSize)
+		for i := 0; i < config.ReadPoolSize; i++ {
+			c := client
+			if i > 0 {
+				var cerr error
+				c, cerr = ladybug.OpenConnection(database)
+				if cerr != nil {
+					log.Printf("Warning: read pool connection %d/%d failed, continuing with %d: %v",
+						i+1, config.ReadPoolSize, i, cerr)
+					break
+				}
+				driver.readConns = append(driver.readConns, c)
+			}
+			pool <- c
+		}
+		if len(pool) > 1 {
+			driver.readPool = pool
+		} else {
+			// Only the primary made it in; keep the mutex path and release the pool.
+			close(pool)
+		}
+	}
+
 	// Load FTS extension for this connection
 	// Extensions must be loaded for each session (connection)
 	ftsResult, err := client.Query("LOAD EXTENSION FTS;")
@@ -638,10 +682,24 @@ func (k *LadybugDriver) writeWorker() {
 
 // executeQueryInternal performs the actual query execution with mutex protection
 func (k *LadybugDriver) executeQueryInternal(cypherQuery string, kwargs map[string]any) (any, any, any, error) {
+	// Read-only drivers borrow a private connection so concurrent reads proceed in
+	// parallel; each connection is still used by exactly one goroutine at a time,
+	// which is the property the C++ library actually requires.
+	if k.readPool != nil {
+		conn := <-k.readPool
+		defer func() { k.readPool <- conn }()
+		return k.executeOnConn(conn, cypherQuery, kwargs)
+	}
 	// Lock to prevent concurrent database access (ladybug C++ library is not thread-safe)
 	k.mu.Lock()
 	defer k.mu.Unlock()
+	return k.executeOnConn(k.client, cypherQuery, kwargs)
+}
 
+// executeOnConn runs a query on a SPECIFIC connection. Callers must guarantee the
+// connection is not shared concurrently — either by holding k.mu (single-client
+// path) or by having borrowed it from readPool.
+func (k *LadybugDriver) executeOnConn(client *ladybug.Connection, cypherQuery string, kwargs map[string]any) (any, any, any, error) {
 	// Filter parameters exactly like Python implementation
 	params := make(map[string]any) // Use 'any' instead of 'interface{}' for go-ladybug compatibility
 	maps.Copy(params, kwargs)
@@ -656,7 +714,7 @@ func (k *LadybugDriver) executeQueryInternal(cypherQuery string, kwargs map[stri
 	// Check if we have parameters to use prepared statement
 	if len(params) > 0 {
 		// Use prepared statement for parameterized queries
-		preparedStatement, err := k.client.Prepare(cypherQuery)
+		preparedStatement, err := client.Prepare(cypherQuery)
 		if err != nil {
 			// Log error with truncated params for debugging (matching Python behavior)
 			truncatedParams := make(map[string]any)
@@ -671,7 +729,7 @@ func (k *LadybugDriver) executeQueryInternal(cypherQuery string, kwargs map[stri
 			return nil, nil, nil, err
 		}
 
-		results, err = k.client.Execute(preparedStatement, params)
+		results, err = client.Execute(preparedStatement, params)
 		if err != nil {
 			// Log error with truncated params for debugging (matching Python behavior)
 			truncatedParams := make(map[string]any)
@@ -687,7 +745,7 @@ func (k *LadybugDriver) executeQueryInternal(cypherQuery string, kwargs map[stri
 		}
 	} else {
 		// Use simple Query for queries without parameters
-		results, err = k.client.Query(cypherQuery)
+		results, err = client.Query(cypherQuery)
 		if err != nil {
 			log.Printf("Error executing ladybug query: %v\nQuery: %s", err, cypherQuery)
 			return nil, nil, nil, err
@@ -759,6 +817,25 @@ func (k *LadybugDriver) Close() error {
 			log.Printf("Cleaned up temporary database copy at %s", tempDir)
 		}
 	}
+
+	// Close pooled read connections before the primary. Drain the channel first so
+	// no in-flight borrower is holding one; readConns excludes the primary client,
+	// which is closed just below, so nothing is double-closed.
+	if k.readPool != nil {
+		for i := 0; i < cap(k.readPool); i++ {
+			select {
+			case <-k.readPool:
+			default:
+			}
+		}
+		k.readPool = nil
+	}
+	for _, c := range k.readConns {
+		if c != nil {
+			c.Close()
+		}
+	}
+	k.readConns = nil
 
 	// Explicitly close connection and database to ensure lock is released
 	if k.client != nil {

--- a/pkg/router/config.go
+++ b/pkg/router/config.go
@@ -190,6 +190,20 @@ func topicQueryThreads() int {
 	return defaultTopicQueryThreads
 }
 
+// defaultTopicReadPoolSize is how many connections each read-only topic graph
+// opens for concurrent reads. Matches the default query-thread count so a graph
+// can service a full fan-out without queueing.
+const defaultTopicReadPoolSize = 4
+
+// topicReadPoolSize returns the per-graph read connection count, overridable via
+// PREDICATO_TOPIC_READ_POOL.
+func topicReadPoolSize() int {
+	if v := envBytes("PREDICATO_TOPIC_READ_POOL"); v > 0 && v <= 32 {
+		return int(v)
+	}
+	return defaultTopicReadPoolSize
+}
+
 // maxDbSizeForTopicGraph returns the per-graph virtual-size reservation.
 func maxDbSizeForTopicGraph() uint64 {
 	if v := envBytes("PREDICATO_TOPIC_MAX_DB_SIZE_BYTES"); v > 0 {

--- a/pkg/router/driver_ladybug.go
+++ b/pkg/router/driver_ladybug.go
@@ -36,6 +36,12 @@ func init() {
 			// request. Read-only topic graphs are never written to, so widening this
 			// only adds scan/probe parallelism.
 			cfg.MaxConcurrentQueries = topicQueryThreads()
+			// One connection per graph behind a mutex serialised every read, so a
+			// caller fanning out over a graph (topic grounding, the recheck, the
+			// router's own fan-out) got no parallelism at all — the concurrency
+			// collapsed to the number of DISTINCT graphs a request happened to touch,
+			// which for topic-clustered queries is one or two.
+			cfg.ReadPoolSize = topicReadPoolSize()
 		}
 		return driver.NewLadybugDriverWithConfig(cfg)
 	})


### PR DESCRIPTION
## Problem

A `LadybugDriver` holds ONE connection guarded by a mutex, so every read against a graph serialises. Callers that fan out over a graph — topic grounding, the KB recheck, the router's own multi-client search — get no parallelism: their concurrency collapses to the number of *distinct graphs* a request touches, which for topic-clustered queries is one or two.

Measured on a live node with per-stage timings:

| stage | searches | time |
|---|---|---|
| `groundQuestionTopics` | 4, issued concurrently | 3.8–5.9s |
| evidence `gather` | 1 | 0.9–2.4s |

Four "concurrent" searches costing four times one search is the signature of serialisation, not of expensive queries.

## Change

The mutex exists because a single ladybug `Connection` is not thread-safe. The `Database` supports many independent `Connection`s — which is how pensiero already runs a 2–4 connection pool per graph in production.

Read-only drivers now open a small pool and borrow a private connection per query, so each connection is still used by exactly one goroutine at a time — the property the C++ library actually requires.

Scoped deliberately:
- Read-write drivers are untouched and keep the single-client path (writes are already serialised through `writeQueue`).
- The pool only engages when `ReadPoolSize > 1`, which only the topic router sets (`PREDICATO_TOPIC_READ_POOL`, default 4).
- Pool creation is best-effort: if extra connections fail to open we run with fewer; with none we fall back to the original mutex path.

## Why this is a PR rather than a push to main

The vendored darwin ladybug lib is out of sync with the Go bindings (undefined arrow symbols at link time), so **the driver test suite cannot be run locally**. `go build` and `go vet` pass under `-tags system_ladybug`, but for a change to shared-driver thread safety that is not sufficient evidence — the CGO test job here is the gate.

Please confirm the CGO tests pass before merging.